### PR TITLE
Add missing Dependabot ecosystems (docker, github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,15 @@ updates:
         applies-to: version-updates
         patterns:
           - "@angular*"
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/backend/src/main/docker"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Dependabot previously covered maven (`/backend`) and npm (`/frontend`) only.
- Adds `docker` coverage for both Dockerfile locations (`/frontend`, `/backend/src/main/docker`) and a `github-actions` ecosystem entry.

Part of an org-wide public-repo hygiene pass (Dependabot coverage + branch protection).