### PR TITLE
Expand README with tech stack and getting-started commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@ The Toeggelomat has been created to improve breaks and increase the fun of playi
 ## Screenshot
 
 ![alt text](https://spoud.io/wp-content/uploads/2020/02/toeggelomat.png "Screenshot of the Toeggelomat")
+
+## Tech stack
+
+- `backend/` — Quarkus (Java 21), Hibernate ORM with Panache, Flyway migrations, PostgreSQL
+- `frontend/` — Angular, ng-bootstrap, Apollo GraphQL client
+
+## Getting started
+
+```bash
+cd backend
+./mvnw quarkus:dev    # dev mode with hot reload; Quarkus Dev Services will spin up PostgreSQL automatically if Docker is running
+```
+
+```bash
+cd frontend
+npm install
+npm start              # dev server, proxies API calls to the backend (see proxy.conf.json)
+```
+
+`docker-compose.yml` at the repo root brings up a full stack (Traefik + built frontend/backend images) for a production-like local run.


### PR DESCRIPTION
## Summary
- README was just a purpose statement and a screenshot.
- Adds the actual tech stack (Quarkus/Hibernate/Flyway/PostgreSQL backend, Angular/Apollo frontend) and local dev commands for both.