### PR TITLE
Group ng-bootstrap with Angular and graphql-codegen packages in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
         applies-to: version-updates
         patterns:
           - "@angular*"
+          - "@ng-bootstrap/ng-bootstrap"
+      graphql-codegen:
+        applies-to: version-updates
+        patterns:
+          - "@graphql-codegen*"
   - package-ecosystem: "docker"
     directory: "/frontend"
     schedule:


### PR DESCRIPTION
## Summary
- Adds `@ng-bootstrap/ng-bootstrap` to the existing `angular` Dependabot group (it's tightly version-coupled to Angular — v21 requires Angular `^22.0.0`)
- Adds a new `graphql-codegen` group for `@graphql-codegen*` packages (they generate `src/generated/graphql.ts` together via one codegen run and must stay compatible)

## Why
This closes the loop on #385: 4 of the 5 recently-closed Dependabot PRs (#321, #382, #370, #368) failed CI purely because interdependent packages were bumped one at a time. Grouping them means future Dependabot runs propose coordinated bumps instead of individually-broken ones.

## Test plan
- [x] N/A — config-only change, verified as valid YAML