### PR TITLE
Make the build-frontend required check always report on PRs

### DIFF
--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -7,11 +7,27 @@ on:
       - '*'
   pull_request:
     branches: [ main ]
-    paths: [ 'frontend/**' ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+
   build:
     runs-on: ubuntu-latest
+    needs: changes
+    # required check must always report, so only skip the real work when this
+    # is a PR that doesn't touch frontend/ - push/tag builds always run
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true')
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Problem

`build-frontend.yaml`'s `pull_request` trigger is path-filtered to `frontend/**`. Branch protection requires the `build` status check to pass before merge — but for PRs that never touch `frontend/` (e.g. `actions/*` or Docker bumps like #387, #388), that workflow never runs at all, so the required check never reports and the PR sits `BLOCKED` forever, even after approval.

## Fix

Split the workflow into a `changes` job (via `dorny/paths-filter`) and the `build` job. `build` now always runs and always reports a conclusion:
- If the PR touches `frontend/**`, it does the real install/generate/build as before.
- If not, it reports `skipped` (which satisfies a required check) instead of never running.

Push/tag builds to `main` are unaffected — they always do the real build, same as before.