### PR TITLE
Add player create/delete (soft-delete) support

### DIFF
--- a/backend/src/main/java/io/spoud/api/PlayerResource.java
+++ b/backend/src/main/java/io/spoud/api/PlayerResource.java
@@ -5,6 +5,7 @@ import io.spoud.api.data.PlayerTO;
 import io.spoud.api.data.TeamTO;
 import io.spoud.entities.PlayerEO;
 import io.spoud.repositories.PlayerRepository;
+import io.spoud.services.PlayerService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -12,20 +13,34 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
 
 import java.util.List;
+import java.util.UUID;
 
 @GraphQLApi
 public class PlayerResource {
 
   @Inject PlayerRepository playerRepository;
 
+  @Inject PlayerService playerService;
+
   @Query("allPlayers")
   public @NonNull List<@NonNull PlayerTO> findAll() {
-    return playerRepository.findAll().list().stream().map(PlayerTO::from).toList();
+    return playerRepository.findAllActive().stream().map(PlayerTO::from).toList();
+  }
+
+  @Mutation("createPlayer")
+  public @NonNull PlayerTO createPlayer(@NonNull String nickName) {
+    return PlayerTO.from(playerService.createPlayer(nickName));
+  }
+
+  @Mutation("deletePlayer")
+  public @NonNull Boolean deletePlayer(@NonNull UUID uuid) {
+    return playerService.archivePlayer(uuid);
   }
 
   public @NonNull PlayerTO offensePlayer(@Source @NonNull TeamTO teamTO) {

--- a/backend/src/main/java/io/spoud/entities/PlayerEO.java
+++ b/backend/src/main/java/io/spoud/entities/PlayerEO.java
@@ -35,6 +35,9 @@ public class PlayerEO extends PanacheEntityBase implements Cloneable {
   @Column(name = "last_match_time", nullable = true)
   public ZonedDateTime lastMatchTime;
 
+  @Column(name = "active", nullable = false)
+  public Boolean active = true;
+
   public PlayerEO clone() {
     PlayerEO player = new PlayerEO();
     player.uuid = uuid;
@@ -43,6 +46,7 @@ public class PlayerEO extends PanacheEntityBase implements Cloneable {
     player.defensePoints = defensePoints;
     player.offensePoints = offensePoints;
     player.lastMatchTime = lastMatchTime;
+    player.active = active;
     return player;
   }
 }

--- a/backend/src/main/java/io/spoud/repositories/PlayerRepository.java
+++ b/backend/src/main/java/io/spoud/repositories/PlayerRepository.java
@@ -4,10 +4,15 @@ import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.Parameters;
 import io.spoud.entities.PlayerEO;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
 import java.util.UUID;
 
 @ApplicationScoped
 public class PlayerRepository implements PanacheRepositoryBase<PlayerEO, UUID> {
+
+  public List<PlayerEO> findAllActive() {
+    return list("active", true);
+  }
 
   public void updatePointsAndLastMatch(PlayerEO player) {
     update(

--- a/backend/src/main/java/io/spoud/services/PlayerService.java
+++ b/backend/src/main/java/io/spoud/services/PlayerService.java
@@ -1,0 +1,38 @@
+package io.spoud.services;
+
+import io.spoud.entities.PlayerEO;
+import io.spoud.repositories.PlayerRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+
+@ApplicationScoped
+@Transactional
+public class PlayerService {
+
+  private static final int STARTING_POINTS = 500;
+
+  @Inject PlayerRepository playerRepository;
+
+  public PlayerEO createPlayer(String nickName) {
+    PlayerEO player = new PlayerEO();
+    player.uuid = UUID.randomUUID();
+    player.nickName = nickName;
+    player.defensePoints = STARTING_POINTS;
+    player.offensePoints = STARTING_POINTS;
+    player.active = true;
+    playerRepository.persistAndFlush(player);
+    return player;
+  }
+
+  public boolean archivePlayer(UUID uuid) {
+    PlayerEO player = playerRepository.findById(uuid);
+    if (player == null) {
+      return false;
+    }
+    player.active = false;
+    playerRepository.persistAndFlush(player);
+    return true;
+  }
+}

--- a/backend/src/main/resources/db/migration/V1.3.0__player-active-flag.sql
+++ b/backend/src/main/resources/db/migration/V1.3.0__player-active-flag.sql
@@ -1,0 +1,6 @@
+ALTER TABLE t_player ADD COLUMN active BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- email is not used anywhere in the app (not exposed via GraphQL, never
+-- read/written outside the initial seed data); relax it so creating a
+-- player through the new createPlayer mutation only requires a nickname.
+ALTER TABLE t_player ALTER COLUMN email DROP NOT NULL;

--- a/backend/src/test/java/io/spoud/api/PlayerResourceTest.java
+++ b/backend/src/test/java/io/spoud/api/PlayerResourceTest.java
@@ -2,22 +2,67 @@ package io.spoud.api;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.spoud.api.data.PlayerTO;
+import io.spoud.entities.PlayerEO;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 class PlayerResourceTest {
 
+  private static final List<UUID> SEED_PLAYER_UUIDS = List.of(
+    UUID.fromString("f7ec8a9c-09d6-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480afb4-00c5-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480ac12-00c5-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480a9a6-00c5-11ea-8d71-362b9e155667"));
+
   @Inject
   PlayerResource playerResource;
+
+  @AfterEach
+  @Transactional
+  void cleanup() {
+    PlayerEO.delete("uuid not in ?1", SEED_PLAYER_UUIDS);
+    PlayerEO.update("active = true where uuid in ?1", SEED_PLAYER_UUIDS);
+  }
 
   @Test
   void should_return_player() {
     List<PlayerTO> players = playerResource.findAll();
     assertThat(players).hasSize(4);
+  }
+
+  @Test
+  void should_create_a_player() {
+    PlayerTO created = playerResource.createPlayer("Testy");
+
+    assertThat(created.uuid()).isNotNull();
+    assertThat(created.nickName()).isEqualTo("Testy");
+    assertThat(created.defensePoints()).isEqualTo(500);
+    assertThat(created.offensePoints()).isEqualTo(500);
+    assertThat(playerResource.findAll()).hasSize(5);
+  }
+
+  @Test
+  void should_archive_a_player() {
+    PlayerTO created = playerResource.createPlayer("Testy");
+
+    boolean deleted = playerResource.deletePlayer(created.uuid());
+
+    assertThat(deleted).isTrue();
+    assertThat(playerResource.findAll()).hasSize(4);
+  }
+
+  @Test
+  void should_return_false_when_archiving_unknown_player() {
+    boolean deleted = playerResource.deletePlayer(UUID.randomUUID());
+
+    assertThat(deleted).isFalse();
   }
 }

--- a/frontend/graphql/schema.graphql
+++ b/frontend/graphql/schema.graphql
@@ -13,6 +13,8 @@ type Match {
 
 "Mutation root"
 type Mutation {
+  createPlayer(nickName: String!): Player!
+  deletePlayer(uuid: String!): Boolean!
   randomizeMatch(players: [String!]!): Match!
   saveScore(scores: SaveScoreInput!): Match!
 }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,11 +2,13 @@ import {Routes} from '@angular/router';
 import {PlayersSelectionComponent} from "./players-selection/players-selection.component";
 import {CurrentMatchComponent} from "./current-match/current-match.component";
 import {ScoreboardComponent} from "./scoreboard/scoreboard.component";
+import {ManagePlayersComponent} from "./manage-players/manage-players.component";
 
 export const routes: Routes = [
   {path: 'players-selection', component: PlayersSelectionComponent},
   {path: 'current-match', component: CurrentMatchComponent},
   {path: 'scoreboard', component: ScoreboardComponent},
+  {path: 'manage-players', component: ManagePlayersComponent},
   {
     path: '',
     redirectTo: '/scoreboard',

--- a/frontend/src/app/manage-players/manage-players.component.html
+++ b/frontend/src/app/manage-players/manage-players.component.html
@@ -1,0 +1,34 @@
+<div class="jumbotron">
+  <h1 class="display-3">Manage players</h1>
+  <p class="lead">
+    <input type="text"
+           class="form-control d-inline-block"
+           placeholder="New player nickname"
+           [value]="newPlayerName()"
+           (input)="onNewPlayerNameInput($event)"
+           (keydown.enter)="addPlayer()"/>
+    <button type="button" class="btn btn-primary btn-lg" [disabled]="!newPlayerName().trim()"
+            (click)="addPlayer()">Add player
+    </button>
+    <button type="button" class="btn btn-secondary btn-lg" routerLink="/scoreboard">Back</button>
+  </p>
+</div>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">Nickname</th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (player of players(); track player.uuid) {
+      <tr>
+        <td>{{ player.nickName }}</td>
+        <td>
+          <button type="button" class="btn btn-outline-danger btn-sm" (click)="archivePlayer(player.uuid)">Archive</button>
+        </td>
+      </tr>
+    }
+  </tbody>
+</table>

--- a/frontend/src/app/manage-players/manage-players.component.ts
+++ b/frontend/src/app/manage-players/manage-players.component.ts
@@ -1,0 +1,35 @@
+import {Component, inject, signal} from '@angular/core';
+import {RouterLink} from "@angular/router";
+import {PlayersService} from "../services/players-service";
+
+@Component({
+  selector: 'app-manage-players',
+  templateUrl: './manage-players.component.html',
+  styleUrl: './manage-players.component.scss',
+  imports: [
+    RouterLink
+  ]
+})
+export class ManagePlayersComponent {
+
+  private playersService = inject(PlayersService);
+
+  public players = this.playersService.players;
+  public newPlayerName = signal('');
+
+  public onNewPlayerNameInput(event: Event): void {
+    this.newPlayerName.set((event.target as HTMLInputElement).value);
+  }
+
+  public addPlayer(): void {
+    const nickName = this.newPlayerName().trim();
+    if (nickName) {
+      this.playersService.createPlayer(nickName);
+      this.newPlayerName.set('');
+    }
+  }
+
+  public archivePlayer(uuid: string): void {
+    this.playersService.deletePlayer(uuid);
+  }
+}

--- a/frontend/src/app/scoreboard/scoreboard.component.html
+++ b/frontend/src/app/scoreboard/scoreboard.component.html
@@ -1,6 +1,7 @@
 <h1>Score board</h1>
 <div class="start-game-container">
   <button type="button" class="btn btn-primary btn-lg" routerLink="/players-selection">Start a game</button>
+  <button type="button" class="btn btn-secondary btn-lg" routerLink="/manage-players">Manage players</button>
 </div>
 
 <div class="container-fluid">

--- a/frontend/src/app/services/players-service.ts
+++ b/frontend/src/app/services/players-service.ts
@@ -1,5 +1,5 @@
 import {inject, Injectable, Signal, signal} from "@angular/core";
-import {AllPlayersGQL, Player} from "../../generated/graphql";
+import {AllPlayersGQL, CreatePlayerGQL, DeletePlayerGQL, Player} from "../../generated/graphql";
 import {map} from "rxjs/operators";
 
 @Injectable({
@@ -8,6 +8,8 @@ import {map} from "rxjs/operators";
 export class PlayersService {
 
   private allPlayerGql = inject(AllPlayersGQL);
+  private createPlayerGql = inject(CreatePlayerGQL);
+  private deletePlayerGql = inject(DeletePlayerGQL);
 
   private _players = signal<Player[]>([]);
 
@@ -24,6 +26,16 @@ export class PlayersService {
           .sort((l, r) => (r.defensePoints + r.offensePoints) - (l.defensePoints + l.offensePoints)))
       )
       .subscribe(this._players.set);
+  }
+
+  public createPlayer(nickName: string): void {
+    this.createPlayerGql.mutate({variables: {nickName}})
+      .subscribe(() => this.reloadPlayers());
+  }
+
+  public deletePlayer(uuid: string): void {
+    this.deletePlayerGql.mutate({variables: {uuid}})
+      .subscribe(() => this.reloadPlayers());
   }
 
   get players(): Signal<Player[]> {

--- a/frontend/src/graphql/mutation-create-player.graphql
+++ b/frontend/src/graphql/mutation-create-player.graphql
@@ -1,0 +1,9 @@
+mutation CreatePlayer($nickName: String!) {
+  createPlayer(nickName: $nickName) {
+    uuid
+    nickName
+    lastMatchTime
+    defensePoints
+    offensePoints
+  }
+}

--- a/frontend/src/graphql/mutation-delete-player.graphql
+++ b/frontend/src/graphql/mutation-delete-player.graphql
@@ -1,0 +1,3 @@
+mutation DeletePlayer($uuid: String!) {
+  deletePlayer(uuid: $uuid)
+}


### PR DESCRIPTION
Closes #6.

## What

- Backend: `createPlayer(nickName: String!): Player!` and `deletePlayer(uuid: String!): Boolean!` GraphQL mutations, backed by a new `PlayerService`.
- `active` boolean added to `t_player` (migration `V1.3.0`) — deletion is a **soft delete** (archive), since matches store player UUIDs and a hard delete would break match history / stats. `allPlayers` now only returns active players by default.
- `email` relaxed to nullable in the same migration: it's never exposed via GraphQL or used anywhere in the app, so requiring it on `createPlayer` would only be friction with no purpose.
- Frontend: new "Manage players" page (`/manage-players`, linked from the scoreboard) with an add-player form and an Archive button per player, wired through `PlayersService`.
- Added backend tests for `createPlayer`/`deletePlayer` (including the not-found case) alongside the existing `PlayerResourceTest`.

## Test plan
- [x] `./mvnw test` — all 6 backend tests pass (3 new)
- [x] `npm run generate && npm run build` — clean
- [x] Manual smoke test: created a player via the UI, confirmed it appears in both the scoreboard/player-selection screens, archived it via the UI, confirmed it disappears from the list and `allPlayers` on the backend