### PR TITLE
Add a persistent top navigation bar

### DIFF
--- a/backend/src/main/java/io/spoud/api/PlayerResource.java
+++ b/backend/src/main/java/io/spoud/api/PlayerResource.java
@@ -33,6 +33,11 @@ public class PlayerResource {
     return playerRepository.findAllActive().stream().map(PlayerTO::from).toList();
   }
 
+  @Query("archivedPlayers")
+  public @NonNull List<@NonNull PlayerTO> findAllArchived() {
+    return playerRepository.findAllArchived().stream().map(PlayerTO::from).toList();
+  }
+
   @Mutation("createPlayer")
   public @NonNull PlayerTO createPlayer(@NonNull String nickName) {
     return PlayerTO.from(playerService.createPlayer(nickName));
@@ -41,6 +46,11 @@ public class PlayerResource {
   @Mutation("deletePlayer")
   public @NonNull Boolean deletePlayer(@NonNull UUID uuid) {
     return playerService.archivePlayer(uuid);
+  }
+
+  @Mutation("unarchivePlayer")
+  public @NonNull Boolean unarchivePlayer(@NonNull UUID uuid) {
+    return playerService.unarchivePlayer(uuid);
   }
 
   public @NonNull PlayerTO offensePlayer(@Source @NonNull TeamTO teamTO) {

--- a/backend/src/main/java/io/spoud/repositories/PlayerRepository.java
+++ b/backend/src/main/java/io/spoud/repositories/PlayerRepository.java
@@ -14,6 +14,10 @@ public class PlayerRepository implements PanacheRepositoryBase<PlayerEO, UUID> {
     return list("active", true);
   }
 
+  public List<PlayerEO> findAllArchived() {
+    return list("active", false);
+  }
+
   public void updatePointsAndLastMatch(PlayerEO player) {
     update(
         "offensePoints = :offensePoints, defensePoints = :defensePoints, lastMatchTime = :lastMatchTime where uuid = :uuid",

--- a/backend/src/main/java/io/spoud/services/PlayerService.java
+++ b/backend/src/main/java/io/spoud/services/PlayerService.java
@@ -35,4 +35,14 @@ public class PlayerService {
     playerRepository.persistAndFlush(player);
     return true;
   }
+
+  public boolean unarchivePlayer(UUID uuid) {
+    PlayerEO player = playerRepository.findById(uuid);
+    if (player == null) {
+      return false;
+    }
+    player.active = true;
+    playerRepository.persistAndFlush(player);
+    return true;
+  }
 }

--- a/backend/src/test/java/io/spoud/api/PlayerResourceTest.java
+++ b/backend/src/test/java/io/spoud/api/PlayerResourceTest.java
@@ -65,4 +65,34 @@ class PlayerResourceTest {
 
     assertThat(deleted).isFalse();
   }
+
+  @Test
+  void should_list_archived_players() {
+    PlayerTO created = playerResource.createPlayer("Testy");
+    playerResource.deletePlayer(created.uuid());
+
+    List<PlayerTO> archived = playerResource.findAllArchived();
+
+    assertThat(archived).extracting(PlayerTO::uuid).containsExactly(created.uuid());
+    assertThat(playerResource.findAll()).hasSize(4);
+  }
+
+  @Test
+  void should_unarchive_a_player() {
+    PlayerTO created = playerResource.createPlayer("Testy");
+    playerResource.deletePlayer(created.uuid());
+
+    boolean unarchived = playerResource.unarchivePlayer(created.uuid());
+
+    assertThat(unarchived).isTrue();
+    assertThat(playerResource.findAll()).hasSize(5);
+    assertThat(playerResource.findAllArchived()).isEmpty();
+  }
+
+  @Test
+  void should_return_false_when_unarchiving_unknown_player() {
+    boolean unarchived = playerResource.unarchivePlayer(UUID.randomUUID());
+
+    assertThat(unarchived).isFalse();
+  }
 }

--- a/frontend/graphql/schema.graphql
+++ b/frontend/graphql/schema.graphql
@@ -17,6 +17,7 @@ type Mutation {
   deletePlayer(uuid: String!): Boolean!
   randomizeMatch(players: [String!]!): Match!
   saveScore(scores: SaveScoreInput!): Match!
+  unarchivePlayer(uuid: String!): Boolean!
 }
 
 type Player {
@@ -31,6 +32,7 @@ type Player {
 "Query root"
 type Query {
   allPlayers: [Player!]!
+  archivedPlayers: [Player!]!
   lastMatches: [Match!]!
 }
 

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,1 +1,2 @@
+<app-nav></app-nav>
 <router-outlet></router-outlet>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,12 +1,14 @@
 import {Component} from '@angular/core';
 import {RouterModule} from "@angular/router";
+import {NavComponent} from "./nav/nav.component";
 
 @Component({
     selector: 'app-root',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.css'],
     imports: [
-        RouterModule
+        RouterModule,
+        NavComponent
     ]
 })
 export class AppComponent {

--- a/frontend/src/app/manage-players/manage-players.component.html
+++ b/frontend/src/app/manage-players/manage-players.component.html
@@ -10,7 +10,6 @@
     <button type="button" class="btn btn-primary btn-lg" [disabled]="!newPlayerName().trim()"
             (click)="addPlayer()">Add player
     </button>
-    <button type="button" class="btn btn-secondary btn-lg" routerLink="/scoreboard">Back</button>
   </p>
 </div>
 

--- a/frontend/src/app/manage-players/manage-players.component.html
+++ b/frontend/src/app/manage-players/manage-players.component.html
@@ -31,3 +31,25 @@
     }
   </tbody>
 </table>
+
+@if (archivedPlayers().length > 0) {
+  <h2>Archived players</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th scope="col">Nickname</th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (player of archivedPlayers(); track player.uuid) {
+        <tr>
+          <td>{{ player.nickName }}</td>
+          <td>
+            <button type="button" class="btn btn-outline-success btn-sm" (click)="unarchivePlayer(player.uuid)">Unarchive</button>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+}

--- a/frontend/src/app/manage-players/manage-players.component.ts
+++ b/frontend/src/app/manage-players/manage-players.component.ts
@@ -1,14 +1,11 @@
 import {Component, inject, signal} from '@angular/core';
-import {RouterLink} from "@angular/router";
 import {PlayersService} from "../services/players-service";
 
 @Component({
   selector: 'app-manage-players',
   templateUrl: './manage-players.component.html',
   styleUrl: './manage-players.component.scss',
-  imports: [
-    RouterLink
-  ]
+  imports: []
 })
 export class ManagePlayersComponent {
 

--- a/frontend/src/app/manage-players/manage-players.component.ts
+++ b/frontend/src/app/manage-players/manage-players.component.ts
@@ -12,7 +12,12 @@ export class ManagePlayersComponent {
   private playersService = inject(PlayersService);
 
   public players = this.playersService.players;
+  public archivedPlayers = this.playersService.archivedPlayers;
   public newPlayerName = signal('');
+
+  constructor() {
+    this.playersService.reloadArchivedPlayers();
+  }
 
   public onNewPlayerNameInput(event: Event): void {
     this.newPlayerName.set((event.target as HTMLInputElement).value);
@@ -28,5 +33,9 @@ export class ManagePlayersComponent {
 
   public archivePlayer(uuid: string): void {
     this.playersService.deletePlayer(uuid);
+  }
+
+  public unarchivePlayer(uuid: string): void {
+    this.playersService.unarchivePlayer(uuid);
   }
 }

--- a/frontend/src/app/nav/nav.component.html
+++ b/frontend/src/app/nav/nav.component.html
@@ -1,0 +1,20 @@
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" routerLink="/scoreboard">Toeggelomat</a>
+    <button class="navbar-toggler" type="button"
+            [attr.aria-expanded]="!isCollapsed()"
+            aria-label="Toggle navigation"
+            (click)="isCollapsed.set(!isCollapsed())">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="navbar-collapse" [ngbCollapse]="isCollapsed()">
+      <ul class="navbar-nav">
+        @for (link of links; track link.path) {
+          <li class="nav-item">
+            <a class="nav-link" [routerLink]="link.path" routerLinkActive="active">{{ link.label }}</a>
+          </li>
+        }
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/frontend/src/app/nav/nav.component.scss
+++ b/frontend/src/app/nav/nav.component.scss
@@ -1,0 +1,3 @@
+.navbar-nav .nav-link.active {
+  font-weight: bold;
+}

--- a/frontend/src/app/nav/nav.component.ts
+++ b/frontend/src/app/nav/nav.component.ts
@@ -1,0 +1,27 @@
+import {Component, signal} from '@angular/core';
+import {RouterModule} from "@angular/router";
+import {NgbCollapseModule} from "@ng-bootstrap/ng-bootstrap";
+
+interface NavLink {
+  label: string;
+  path: string;
+}
+
+@Component({
+  selector: 'app-nav',
+  templateUrl: './nav.component.html',
+  styleUrl: './nav.component.scss',
+  imports: [
+    RouterModule,
+    NgbCollapseModule
+  ]
+})
+export class NavComponent {
+
+  public links: NavLink[] = [
+    {label: 'Scoreboard', path: '/scoreboard'},
+    {label: 'Manage players', path: '/manage-players'},
+  ];
+
+  public isCollapsed = signal(true);
+}

--- a/frontend/src/app/scoreboard/scoreboard.component.html
+++ b/frontend/src/app/scoreboard/scoreboard.component.html
@@ -1,7 +1,6 @@
 <h1>Score board</h1>
 <div class="start-game-container">
   <button type="button" class="btn btn-primary btn-lg" routerLink="/players-selection">Start a game</button>
-  <button type="button" class="btn btn-secondary btn-lg" routerLink="/manage-players">Manage players</button>
 </div>
 
 <div class="container-fluid">

--- a/frontend/src/app/services/players-service.ts
+++ b/frontend/src/app/services/players-service.ts
@@ -1,5 +1,12 @@
 import {inject, Injectable, Signal, signal} from "@angular/core";
-import {AllPlayersGQL, CreatePlayerGQL, DeletePlayerGQL, Player} from "../../generated/graphql";
+import {
+  AllPlayersGQL,
+  ArchivedPlayersGQL,
+  CreatePlayerGQL,
+  DeletePlayerGQL,
+  Player,
+  UnarchivePlayerGQL
+} from "../../generated/graphql";
 import {map} from "rxjs/operators";
 
 @Injectable({
@@ -8,10 +15,13 @@ import {map} from "rxjs/operators";
 export class PlayersService {
 
   private allPlayerGql = inject(AllPlayersGQL);
+  private archivedPlayersGql = inject(ArchivedPlayersGQL);
   private createPlayerGql = inject(CreatePlayerGQL);
   private deletePlayerGql = inject(DeletePlayerGQL);
+  private unarchivePlayerGql = inject(UnarchivePlayerGQL);
 
   private _players = signal<Player[]>([]);
+  private _archivedPlayers = signal<Player[]>([]);
 
   constructor() {
     this.reloadPlayers();
@@ -28,6 +38,12 @@ export class PlayersService {
       .subscribe(this._players.set);
   }
 
+  public reloadArchivedPlayers(): void {
+    this.archivedPlayersGql.fetch()
+      .pipe(map(res => res.data?.archivedPlayers as Player[]))
+      .subscribe(this._archivedPlayers.set);
+  }
+
   public createPlayer(nickName: string): void {
     this.createPlayerGql.mutate({variables: {nickName}})
       .subscribe(() => this.reloadPlayers());
@@ -35,10 +51,25 @@ export class PlayersService {
 
   public deletePlayer(uuid: string): void {
     this.deletePlayerGql.mutate({variables: {uuid}})
-      .subscribe(() => this.reloadPlayers());
+      .subscribe(() => {
+        this.reloadPlayers();
+        this.reloadArchivedPlayers();
+      });
+  }
+
+  public unarchivePlayer(uuid: string): void {
+    this.unarchivePlayerGql.mutate({variables: {uuid}})
+      .subscribe(() => {
+        this.reloadPlayers();
+        this.reloadArchivedPlayers();
+      });
   }
 
   get players(): Signal<Player[]> {
     return this._players;
+  }
+
+  get archivedPlayers(): Signal<Player[]> {
+    return this._archivedPlayers;
   }
 }

--- a/frontend/src/graphql/mutation-unarchive-player.graphql
+++ b/frontend/src/graphql/mutation-unarchive-player.graphql
@@ -1,0 +1,3 @@
+mutation UnarchivePlayer($uuid: String!) {
+  unarchivePlayer(uuid: $uuid)
+}

--- a/frontend/src/graphql/query-archived-players.graphql
+++ b/frontend/src/graphql/query-archived-players.graphql
@@ -1,0 +1,9 @@
+query archivedPlayers {
+  archivedPlayers {
+    uuid
+    nickName
+    lastMatchTime
+    defensePoints
+    offensePoints
+  }
+}


### PR DESCRIPTION
Stacked on #398 (uses the \`manage-players\` page it adds) — base branch is \`feature/player-crud\`, not \`main\`, until that one merges. The diff will narrow to just this PR's changes once #398 lands.

## Why

No persistent nav existed — `app.component.html` was a bare `<router-outlet>`, so every page wired its own ad-hoc buttons. Concretely: the Scoreboard page had "Start a game" (its primary action) sitting next to "Manage players" (an unrelated admin action) as equally-weighted buttons. This was only going to get worse as more pages land (Seasons #8, player statistics #7 are next on the roadmap).

## What

- New `NavComponent` (`frontend/src/app/nav/`) — a Bootstrap navbar with a brand link and Scoreboard/Manage players links, using `NgbCollapse` for the mobile toggle (a pure Angular directive, sidesteps the pre-existing Bootstrap 4 CDN vs ng-bootstrap 21/Bootstrap 5 mismatch rather than trying to fix that unrelated issue here).
- Rendered above `<router-outlet>` in `app.component.html` so it's present on every route.
- The link list is a small literal array, so adding a future page is a one-line change.
- Removed "Manage players" from the Scoreboard page (now in the nav) and the now-redundant "Back" button from the Manage players page.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm run test` all pass
- [x] Manual browser check: nav renders on Scoreboard and Manage players, active link highlights correctly when navigating between them, Scoreboard now shows only "Start a game"
- [ ] Mobile-width collapse toggle — implemented per the standard Bootstrap navbar + NgbCollapse pattern, but I wasn't able to force a narrow viewport in my browser tooling to visually confirm; worth a quick manual check on your end