### PR TITLE
Show archived players on the manage-players page, with unarchive

### DIFF
--- a/backend/src/main/java/io/spoud/api/PlayerResource.java
+++ b/backend/src/main/java/io/spoud/api/PlayerResource.java
@@ -33,6 +33,11 @@ public class PlayerResource {
     return playerRepository.findAllActive().stream().map(PlayerTO::from).toList();
   }
 
+  @Query("archivedPlayers")
+  public @NonNull List<@NonNull PlayerTO> findAllArchived() {
+    return playerRepository.findAllArchived().stream().map(PlayerTO::from).toList();
+  }
+
   @Mutation("createPlayer")
   public @NonNull PlayerTO createPlayer(@NonNull String nickName) {
     return PlayerTO.from(playerService.createPlayer(nickName));
@@ -41,6 +46,11 @@ public class PlayerResource {
   @Mutation("deletePlayer")
   public @NonNull Boolean deletePlayer(@NonNull UUID uuid) {
     return playerService.archivePlayer(uuid);
+  }
+
+  @Mutation("unarchivePlayer")
+  public @NonNull Boolean unarchivePlayer(@NonNull UUID uuid) {
+    return playerService.unarchivePlayer(uuid);
   }
 
   public @NonNull PlayerTO offensePlayer(@Source @NonNull TeamTO teamTO) {

--- a/backend/src/main/java/io/spoud/repositories/PlayerRepository.java
+++ b/backend/src/main/java/io/spoud/repositories/PlayerRepository.java
@@ -14,6 +14,10 @@ public class PlayerRepository implements PanacheRepositoryBase<PlayerEO, UUID> {
     return list("active", true);
   }
 
+  public List<PlayerEO> findAllArchived() {
+    return list("active", false);
+  }
+
   public void updatePointsAndLastMatch(PlayerEO player) {
     update(
         "offensePoints = :offensePoints, defensePoints = :defensePoints, lastMatchTime = :lastMatchTime where uuid = :uuid",

--- a/backend/src/main/java/io/spoud/services/PlayerService.java
+++ b/backend/src/main/java/io/spoud/services/PlayerService.java
@@ -35,4 +35,14 @@ public class PlayerService {
     playerRepository.persistAndFlush(player);
     return true;
   }
+
+  public boolean unarchivePlayer(UUID uuid) {
+    PlayerEO player = playerRepository.findById(uuid);
+    if (player == null) {
+      return false;
+    }
+    player.active = true;
+    playerRepository.persistAndFlush(player);
+    return true;
+  }
 }

--- a/backend/src/test/java/io/spoud/api/PlayerResourceTest.java
+++ b/backend/src/test/java/io/spoud/api/PlayerResourceTest.java
@@ -65,4 +65,34 @@ class PlayerResourceTest {
 
     assertThat(deleted).isFalse();
   }
+
+  @Test
+  void should_list_archived_players() {
+    PlayerTO created = playerResource.createPlayer("Testy");
+    playerResource.deletePlayer(created.uuid());
+
+    List<PlayerTO> archived = playerResource.findAllArchived();
+
+    assertThat(archived).extracting(PlayerTO::uuid).containsExactly(created.uuid());
+    assertThat(playerResource.findAll()).hasSize(4);
+  }
+
+  @Test
+  void should_unarchive_a_player() {
+    PlayerTO created = playerResource.createPlayer("Testy");
+    playerResource.deletePlayer(created.uuid());
+
+    boolean unarchived = playerResource.unarchivePlayer(created.uuid());
+
+    assertThat(unarchived).isTrue();
+    assertThat(playerResource.findAll()).hasSize(5);
+    assertThat(playerResource.findAllArchived()).isEmpty();
+  }
+
+  @Test
+  void should_return_false_when_unarchiving_unknown_player() {
+    boolean unarchived = playerResource.unarchivePlayer(UUID.randomUUID());
+
+    assertThat(unarchived).isFalse();
+  }
 }

--- a/frontend/graphql/schema.graphql
+++ b/frontend/graphql/schema.graphql
@@ -17,6 +17,7 @@ type Mutation {
   deletePlayer(uuid: String!): Boolean!
   randomizeMatch(players: [String!]!): Match!
   saveScore(scores: SaveScoreInput!): Match!
+  unarchivePlayer(uuid: String!): Boolean!
 }
 
 type Player {
@@ -31,6 +32,7 @@ type Player {
 "Query root"
 type Query {
   allPlayers: [Player!]!
+  archivedPlayers: [Player!]!
   lastMatches: [Match!]!
 }
 

--- a/frontend/src/app/manage-players/manage-players.component.html
+++ b/frontend/src/app/manage-players/manage-players.component.html
@@ -31,3 +31,25 @@
     }
   </tbody>
 </table>
+
+@if (archivedPlayers().length > 0) {
+  <h2>Archived players</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th scope="col">Nickname</th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (player of archivedPlayers(); track player.uuid) {
+        <tr>
+          <td>{{ player.nickName }}</td>
+          <td>
+            <button type="button" class="btn btn-outline-success btn-sm" (click)="unarchivePlayer(player.uuid)">Unarchive</button>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+}

--- a/frontend/src/app/manage-players/manage-players.component.ts
+++ b/frontend/src/app/manage-players/manage-players.component.ts
@@ -12,7 +12,12 @@ export class ManagePlayersComponent {
   private playersService = inject(PlayersService);
 
   public players = this.playersService.players;
+  public archivedPlayers = this.playersService.archivedPlayers;
   public newPlayerName = signal('');
+
+  constructor() {
+    this.playersService.reloadArchivedPlayers();
+  }
 
   public onNewPlayerNameInput(event: Event): void {
     this.newPlayerName.set((event.target as HTMLInputElement).value);
@@ -28,5 +33,9 @@ export class ManagePlayersComponent {
 
   public archivePlayer(uuid: string): void {
     this.playersService.deletePlayer(uuid);
+  }
+
+  public unarchivePlayer(uuid: string): void {
+    this.playersService.unarchivePlayer(uuid);
   }
 }

--- a/frontend/src/app/services/players-service.ts
+++ b/frontend/src/app/services/players-service.ts
@@ -1,5 +1,12 @@
 import {inject, Injectable, Signal, signal} from "@angular/core";
-import {AllPlayersGQL, CreatePlayerGQL, DeletePlayerGQL, Player} from "../../generated/graphql";
+import {
+  AllPlayersGQL,
+  ArchivedPlayersGQL,
+  CreatePlayerGQL,
+  DeletePlayerGQL,
+  Player,
+  UnarchivePlayerGQL
+} from "../../generated/graphql";
 import {map} from "rxjs/operators";
 
 @Injectable({
@@ -8,10 +15,13 @@ import {map} from "rxjs/operators";
 export class PlayersService {
 
   private allPlayerGql = inject(AllPlayersGQL);
+  private archivedPlayersGql = inject(ArchivedPlayersGQL);
   private createPlayerGql = inject(CreatePlayerGQL);
   private deletePlayerGql = inject(DeletePlayerGQL);
+  private unarchivePlayerGql = inject(UnarchivePlayerGQL);
 
   private _players = signal<Player[]>([]);
+  private _archivedPlayers = signal<Player[]>([]);
 
   constructor() {
     this.reloadPlayers();
@@ -28,6 +38,12 @@ export class PlayersService {
       .subscribe(this._players.set);
   }
 
+  public reloadArchivedPlayers(): void {
+    this.archivedPlayersGql.fetch()
+      .pipe(map(res => res.data?.archivedPlayers as Player[]))
+      .subscribe(this._archivedPlayers.set);
+  }
+
   public createPlayer(nickName: string): void {
     this.createPlayerGql.mutate({variables: {nickName}})
       .subscribe(() => this.reloadPlayers());
@@ -35,10 +51,25 @@ export class PlayersService {
 
   public deletePlayer(uuid: string): void {
     this.deletePlayerGql.mutate({variables: {uuid}})
-      .subscribe(() => this.reloadPlayers());
+      .subscribe(() => {
+        this.reloadPlayers();
+        this.reloadArchivedPlayers();
+      });
+  }
+
+  public unarchivePlayer(uuid: string): void {
+    this.unarchivePlayerGql.mutate({variables: {uuid}})
+      .subscribe(() => {
+        this.reloadPlayers();
+        this.reloadArchivedPlayers();
+      });
   }
 
   get players(): Signal<Player[]> {
     return this._players;
+  }
+
+  get archivedPlayers(): Signal<Player[]> {
+    return this._archivedPlayers;
   }
 }

--- a/frontend/src/graphql/mutation-unarchive-player.graphql
+++ b/frontend/src/graphql/mutation-unarchive-player.graphql
@@ -1,0 +1,3 @@
+mutation UnarchivePlayer($uuid: String!) {
+  unarchivePlayer(uuid: $uuid)
+}

--- a/frontend/src/graphql/query-archived-players.graphql
+++ b/frontend/src/graphql/query-archived-players.graphql
@@ -1,0 +1,9 @@
+query archivedPlayers {
+  archivedPlayers {
+    uuid
+    nickName
+    lastMatchTime
+    defensePoints
+    offensePoints
+  }
+}


### PR DESCRIPTION
Stacked on #399 (nav) → #398 (player CRUD) — base branch is \`feature/persistent-nav\` until those merge. Diff narrows to just this PR once they land.

## Why

Archiving a player (soft-delete from #398) removed them from view entirely with no way back short of a direct DB edit.

## What

- Backend: \`archivedPlayers\` query and \`unarchivePlayer(uuid)\` mutation, mirroring the existing \`allPlayers\`/\`deletePlayer\` pair. 4 new tests.
- Frontend: \`PlayersService\` gains an \`archivedPlayers\` signal (loaded on-demand by the manage-players page, not eagerly on every page) and an \`unarchivePlayer\` method. The manage-players page now has a second "Archived players" table (only shown when non-empty) with an Unarchive button per row.

## Test plan
- [x] \`./mvnw test\` — 9/9 backend tests pass (4 new)
- [x] \`npm run build/lint/test\` — all pass
- [x] Manual browser check: archived players (from earlier testing) show up in the new table; clicking Unarchive moves a player back to the active table and confirmed they reappear in the player-selection screen