### PR TITLE
Add seasons (closes #8)

### DIFF
--- a/backend/src/main/java/io/spoud/api/MatchResource.java
+++ b/backend/src/main/java/io/spoud/api/MatchResource.java
@@ -30,8 +30,8 @@ public class MatchResource {
   }
 
   @Query("lastMatches")
-  public @NonNull List<@NonNull MatchTO> lastMaches() {
-    return matchService.getLastMatchOfTheSeason().stream().map(MatchTO::from).toList();
+  public @NonNull List<@NonNull MatchTO> lastMaches(UUID seasonUuid) {
+    return matchService.getLastMatches(seasonUuid).stream().map(MatchTO::from).toList();
   }
 
   public @NonNull TeamTO redTeam(@Source @NonNull MatchTO match) {

--- a/backend/src/main/java/io/spoud/api/PlayerResource.java
+++ b/backend/src/main/java/io/spoud/api/PlayerResource.java
@@ -6,6 +6,7 @@ import io.spoud.api.data.TeamTO;
 import io.spoud.entities.PlayerEO;
 import io.spoud.repositories.PlayerRepository;
 import io.spoud.services.PlayerService;
+import io.spoud.services.SeasonRankingService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -28,6 +29,8 @@ public class PlayerResource {
 
   @Inject PlayerService playerService;
 
+  @Inject SeasonRankingService seasonRankingService;
+
   @Query("allPlayers")
   public @NonNull List<@NonNull PlayerTO> findAll() {
     return playerRepository.findAllActive().stream().map(PlayerTO::from).toList();
@@ -36,6 +39,22 @@ public class PlayerResource {
   @Query("archivedPlayers")
   public @NonNull List<@NonNull PlayerTO> findAllArchived() {
     return playerRepository.findAllArchived().stream().map(PlayerTO::from).toList();
+  }
+
+  @Query("seasonRanking")
+  public @NonNull List<@NonNull PlayerTO> seasonRanking(@NonNull UUID seasonUuid) {
+    return seasonRankingService.computeRanking(seasonUuid).stream()
+        .map(
+            ranked -> {
+              PlayerEO player = playerRepository.findById(ranked.uuid);
+              return new PlayerTO(
+                  ranked.uuid,
+                  player.nickName,
+                  ranked.defensePoints,
+                  ranked.offensePoints,
+                  ranked.lastMatchTime);
+            })
+        .toList();
   }
 
   @Mutation("createPlayer")

--- a/backend/src/main/java/io/spoud/api/SeasonResource.java
+++ b/backend/src/main/java/io/spoud/api/SeasonResource.java
@@ -1,0 +1,36 @@
+package io.spoud.api;
+
+import io.spoud.api.data.SeasonTO;
+import io.spoud.repositories.SeasonRepository;
+import io.spoud.services.SeasonService;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.NonNull;
+import org.eclipse.microprofile.graphql.Query;
+
+import java.util.List;
+import java.util.UUID;
+
+@GraphQLApi
+public class SeasonResource {
+
+  @Inject SeasonRepository seasonRepository;
+
+  @Inject SeasonService seasonService;
+
+  @Query("allSeasons")
+  public @NonNull List<@NonNull SeasonTO> allSeasons() {
+    return seasonRepository.findAllOrdered().stream().map(SeasonTO::from).toList();
+  }
+
+  @Mutation("createSeason")
+  public @NonNull SeasonTO createSeason(@NonNull String label) {
+    return SeasonTO.from(seasonService.createSeason(label));
+  }
+
+  @Mutation("closeSeason")
+  public @NonNull Boolean closeSeason(@NonNull UUID uuid) {
+    return seasonService.closeSeason(uuid);
+  }
+}

--- a/backend/src/main/java/io/spoud/api/data/SeasonTO.java
+++ b/backend/src/main/java/io/spoud/api/data/SeasonTO.java
@@ -1,0 +1,20 @@
+package io.spoud.api.data;
+
+import io.spoud.entities.SeasonEO;
+import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.NonNull;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Name("Season")
+public record SeasonTO(
+  @NonNull UUID uuid,
+  @NonNull String label,
+  @NonNull ZonedDateTime startTime,
+  ZonedDateTime endTime
+) {
+  public static SeasonTO from(SeasonEO season) {
+    return new SeasonTO(season.uuid, season.label, season.startTime, season.endTime);
+  }
+}

--- a/backend/src/main/java/io/spoud/entities/MatchEO.java
+++ b/backend/src/main/java/io/spoud/entities/MatchEO.java
@@ -46,6 +46,9 @@ public class MatchEO extends PanacheEntityBase {
   @Column(name = "player_blue_offense_uuid", nullable = false)
   public UUID playerBlueOffenseUuid;
 
+  @Column(name = "season_uuid", nullable = true)
+  public UUID seasonUuid;
+
   @Transient public Integer potentialBluePoints;
 
   @Transient public Integer potentialRedPoints;

--- a/backend/src/main/java/io/spoud/entities/SeasonEO.java
+++ b/backend/src/main/java/io/spoud/entities/SeasonEO.java
@@ -1,0 +1,28 @@
+package io.spoud.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "t_season")
+@RegisterForReflection
+public class SeasonEO extends PanacheEntityBase {
+  @Id
+  @Column(name = "season_uuid", unique = true)
+  public UUID uuid;
+
+  @Column(name = "label", length = 100, nullable = false)
+  public String label;
+
+  @Column(name = "start_time", nullable = false)
+  public ZonedDateTime startTime;
+
+  @Column(name = "end_time", nullable = true)
+  public ZonedDateTime endTime;
+}

--- a/backend/src/main/java/io/spoud/repositories/MatchRepository.java
+++ b/backend/src/main/java/io/spoud/repositories/MatchRepository.java
@@ -19,4 +19,8 @@ public class MatchRepository implements PanacheRepositoryBase<MatchEO, UUID> {
         .page(Page.ofSize(nb))
         .list();
   }
+
+  public List<MatchEO> findBySeasonOrderedByTime(UUID seasonUuid) {
+    return find("seasonUuid", Sort.ascending("matchTime"), seasonUuid).list();
+  }
 }

--- a/backend/src/main/java/io/spoud/repositories/MatchRepository.java
+++ b/backend/src/main/java/io/spoud/repositories/MatchRepository.java
@@ -11,7 +11,12 @@ import java.util.UUID;
 @ApplicationScoped
 public class MatchRepository implements PanacheRepositoryBase<MatchEO, UUID> {
 
-  public List<MatchEO> getLastMatches(int nb) {
-    return findAll(Sort.descending("matchTime")).page(Page.ofSize(nb)).list();
+  public List<MatchEO> getLastMatches(int nb, UUID seasonUuid) {
+    if (seasonUuid == null) {
+      return findAll(Sort.descending("matchTime")).page(Page.ofSize(nb)).list();
+    }
+    return find("seasonUuid", Sort.descending("matchTime"), seasonUuid)
+        .page(Page.ofSize(nb))
+        .list();
   }
 }

--- a/backend/src/main/java/io/spoud/repositories/PlayerRepository.java
+++ b/backend/src/main/java/io/spoud/repositories/PlayerRepository.java
@@ -26,4 +26,10 @@ public class PlayerRepository implements PanacheRepositoryBase<PlayerEO, UUID> {
             .and("lastMatchTime", player.lastMatchTime)
             .and("uuid", player.uuid));
   }
+
+  public void resetAllPoints(int startingPoints) {
+    update(
+        "offensePoints = :points, defensePoints = :points",
+        Parameters.with("points", startingPoints));
+  }
 }

--- a/backend/src/main/java/io/spoud/repositories/SeasonRepository.java
+++ b/backend/src/main/java/io/spoud/repositories/SeasonRepository.java
@@ -1,0 +1,20 @@
+package io.spoud.repositories;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import io.spoud.entities.SeasonEO;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@ApplicationScoped
+public class SeasonRepository implements PanacheRepositoryBase<SeasonEO, UUID> {
+
+  public Optional<SeasonEO> findActive() {
+    return find("endTime is null").firstResultOptional();
+  }
+
+  public List<SeasonEO> findAllOrdered() {
+    return list("ORDER BY startTime DESC");
+  }
+}

--- a/backend/src/main/java/io/spoud/services/MatchPointsService.java
+++ b/backend/src/main/java/io/spoud/services/MatchPointsService.java
@@ -67,25 +67,26 @@ public class MatchPointsService {
   }
 
   private int calcPoints(PlayersHelper playersHelper) {
-    double factor = 1.0;
-    factor *= sevenToZeroMultiplier(playersHelper.match);
-    double winnerPoints =
+    int winnerPoints =
       playersHelper.getWinnerDeffence().defensePoints
         + playersHelper.getWinnerOffense().offensePoints;
-    double looserPoints =
+    int looserPoints =
       playersHelper.getLooserDeffence().defensePoints
         + playersHelper.getLooserOffense().offensePoints;
+    return calcPoints(winnerPoints, looserPoints, isSevenToZero(playersHelper.match));
+  }
+
+  public static int calcPoints(int winnerPoints, int looserPoints, boolean sevenToZero) {
+    double factor = sevenToZero ? 2 : 1;
     double total = winnerPoints + looserPoints;
     double slope = slope(looserPoints, total);
     return (int) Math.round(slope * factor * BASE_POINTS);
   }
 
-  private double sevenToZeroMultiplier(MatchEO match) {
+  public static boolean isSevenToZero(MatchEO match) {
     return match.blueScore != null
       && match.redScore != null
-      && (match.blueScore == 0 || match.redScore == 0)
-      ? 2
-      : 1;
+      && (match.blueScore == 0 || match.redScore == 0);
   }
 
   public static class PlayersHelper {

--- a/backend/src/main/java/io/spoud/services/MatchService.java
+++ b/backend/src/main/java/io/spoud/services/MatchService.java
@@ -31,6 +31,9 @@ public class MatchService {
     if (playersUuid.size() < 4) {
       throw new IllegalArgumentException("To few players");
     }
+    if (seasonRepository.findActive().isEmpty()) {
+      throw new IllegalStateException("No active season");
+    }
     MatchEO match =
         matchRandomizeService.randomizeNewMatch(
             2, new HashSet<>(playerRepository.findByIds(playersUuid)));

--- a/backend/src/main/java/io/spoud/services/MatchService.java
+++ b/backend/src/main/java/io/spoud/services/MatchService.java
@@ -4,6 +4,7 @@ import io.spoud.api.data.SaveScoreInput;
 import io.spoud.entities.MatchEO;
 import io.spoud.repositories.MatchRepository;
 import io.spoud.repositories.PlayerRepository;
+import io.spoud.repositories.SeasonRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -19,6 +20,8 @@ public class MatchService {
   @Inject PlayerRepository playerRepository;
 
   @Inject MatchRepository matchRepository;
+
+  @Inject SeasonRepository seasonRepository;
 
   @Inject MatchRandomizeService matchRandomizeService;
 
@@ -45,6 +48,7 @@ public class MatchService {
     match.playerRedOffenseUuid = score.playerRedOffenseUuid();
     match.playerBlueDefenseUuid = score.playerBlueDefenseUuid();
     match.playerBlueOffenseUuid = score.playerBlueOffenseUuid();
+    match.seasonUuid = seasonRepository.findActive().map(season -> season.uuid).orElse(null);
 
     match = matchPointsService.computePointsAndUpdatePlayers(match);
     matchRepository.persistAndFlush(match);
@@ -52,7 +56,7 @@ public class MatchService {
     return match;
   }
 
-  public List<MatchEO> getLastMatchOfTheSeason() {
-    return matchRepository.getLastMatches(20);
+  public List<MatchEO> getLastMatches(UUID seasonUuid) {
+    return matchRepository.getLastMatches(20, seasonUuid);
   }
 }

--- a/backend/src/main/java/io/spoud/services/PlayerService.java
+++ b/backend/src/main/java/io/spoud/services/PlayerService.java
@@ -45,4 +45,8 @@ public class PlayerService {
     playerRepository.persistAndFlush(player);
     return true;
   }
+
+  public void resetAllPointsToStarting() {
+    playerRepository.resetAllPoints(STARTING_POINTS);
+  }
 }

--- a/backend/src/main/java/io/spoud/services/SeasonRankingService.java
+++ b/backend/src/main/java/io/spoud/services/SeasonRankingService.java
@@ -1,0 +1,80 @@
+package io.spoud.services;
+
+import io.spoud.entities.MatchEO;
+import io.spoud.repositories.MatchRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Reconstructs player standings for a given season by replaying its matches in order, starting
+ * every participant at the same baseline used when a season starts. This intentionally does not
+ * read PlayerEO.offensePoints/defensePoints, since those are a single live running total that
+ * gets reset at the start of each new season and would only reflect the current season.
+ */
+@ApplicationScoped
+public class SeasonRankingService {
+
+  private static final int STARTING_POINTS = 500;
+
+  @Inject MatchRepository matchRepository;
+
+  public static class RankedPlayer {
+    public final UUID uuid;
+    public int offensePoints = STARTING_POINTS;
+    public int defensePoints = STARTING_POINTS;
+    public ZonedDateTime lastMatchTime;
+
+    public RankedPlayer(UUID uuid) {
+      this.uuid = uuid;
+    }
+  }
+
+  public List<RankedPlayer> computeRanking(UUID seasonUuid) {
+    List<MatchEO> matches = matchRepository.findBySeasonOrderedByTime(seasonUuid);
+    Map<UUID, RankedPlayer> ranking = new LinkedHashMap<>();
+
+    for (MatchEO match : matches) {
+      RankedPlayer blueDefense =
+          ranking.computeIfAbsent(match.playerBlueDefenseUuid, RankedPlayer::new);
+      RankedPlayer blueOffense =
+          ranking.computeIfAbsent(match.playerBlueOffenseUuid, RankedPlayer::new);
+      RankedPlayer redDefense =
+          ranking.computeIfAbsent(match.playerRedDefenseUuid, RankedPlayer::new);
+      RankedPlayer redOffense =
+          ranking.computeIfAbsent(match.playerRedOffenseUuid, RankedPlayer::new);
+
+      boolean wonByBlue =
+          match.redScore != null && match.blueScore != null
+              ? match.blueScore > match.redScore
+              : true;
+
+      RankedPlayer winnerDefense = wonByBlue ? blueDefense : redDefense;
+      RankedPlayer winnerOffense = wonByBlue ? blueOffense : redOffense;
+      RankedPlayer looserDefense = wonByBlue ? redDefense : blueDefense;
+      RankedPlayer looserOffense = wonByBlue ? redOffense : blueOffense;
+
+      int winnerTotal = winnerDefense.defensePoints + winnerOffense.offensePoints;
+      int looserTotal = looserDefense.defensePoints + looserOffense.offensePoints;
+      boolean sevenToZero = MatchPointsService.isSevenToZero(match);
+      int points = MatchPointsService.calcPoints(winnerTotal, looserTotal, sevenToZero);
+
+      winnerDefense.defensePoints += points + MatchPointsService.ADDITIONAL_POINT_FOR_WINNING;
+      winnerOffense.offensePoints += points + MatchPointsService.ADDITIONAL_POINT_FOR_WINNING;
+      looserDefense.defensePoints += -points + MatchPointsService.ADDITIONAL_POINT_FOR_LOSING;
+      looserOffense.offensePoints += -points + MatchPointsService.ADDITIONAL_POINT_FOR_LOSING;
+
+      blueDefense.lastMatchTime = match.matchTime;
+      blueOffense.lastMatchTime = match.matchTime;
+      redDefense.lastMatchTime = match.matchTime;
+      redOffense.lastMatchTime = match.matchTime;
+    }
+
+    return new ArrayList<>(ranking.values());
+  }
+}

--- a/backend/src/main/java/io/spoud/services/SeasonService.java
+++ b/backend/src/main/java/io/spoud/services/SeasonService.java
@@ -1,0 +1,44 @@
+package io.spoud.services;
+
+import io.spoud.entities.SeasonEO;
+import io.spoud.repositories.SeasonRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@ApplicationScoped
+@Transactional
+public class SeasonService {
+
+  @Inject SeasonRepository seasonRepository;
+
+  public SeasonEO createSeason(String label) {
+    ZonedDateTime now = ZonedDateTime.now();
+    seasonRepository
+        .findActive()
+        .ifPresent(
+            active -> {
+              active.endTime = now;
+              seasonRepository.persist(active);
+            });
+
+    SeasonEO season = new SeasonEO();
+    season.uuid = UUID.randomUUID();
+    season.label = label;
+    season.startTime = now;
+    seasonRepository.persistAndFlush(season);
+    return season;
+  }
+
+  public boolean closeSeason(UUID uuid) {
+    SeasonEO season = seasonRepository.findById(uuid);
+    if (season == null || season.endTime != null) {
+      return false;
+    }
+    season.endTime = ZonedDateTime.now();
+    seasonRepository.persistAndFlush(season);
+    return true;
+  }
+}

--- a/backend/src/main/java/io/spoud/services/SeasonService.java
+++ b/backend/src/main/java/io/spoud/services/SeasonService.java
@@ -14,6 +14,8 @@ public class SeasonService {
 
   @Inject SeasonRepository seasonRepository;
 
+  @Inject PlayerService playerService;
+
   public SeasonEO createSeason(String label) {
     ZonedDateTime now = ZonedDateTime.now();
     seasonRepository
@@ -29,6 +31,9 @@ public class SeasonService {
     season.label = label;
     season.startTime = now;
     seasonRepository.persistAndFlush(season);
+
+    playerService.resetAllPointsToStarting();
+
     return season;
   }
 

--- a/backend/src/main/resources/db/migration/V1.4.0__seasons.sql
+++ b/backend/src/main/resources/db/migration/V1.4.0__seasons.sql
@@ -1,0 +1,11 @@
+CREATE TABLE t_season
+(
+    season_uuid UUID        NOT NULL,
+    label       VARCHAR(100) NOT NULL,
+    start_time  TIMESTAMPTZ NOT NULL,
+    end_time    TIMESTAMPTZ,
+    PRIMARY KEY (season_uuid)
+);
+
+ALTER TABLE t_match ADD COLUMN season_uuid UUID;
+ALTER TABLE t_match ADD CONSTRAINT fk_match_season FOREIGN KEY (season_uuid) REFERENCES t_season (season_uuid);

--- a/backend/src/test/java/io/spoud/api/MatchResourceTest.java
+++ b/backend/src/test/java/io/spoud/api/MatchResourceTest.java
@@ -2,6 +2,7 @@ package io.spoud.api;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.spoud.api.data.MatchTO;
+import io.spoud.api.data.PlayerTO;
 import io.spoud.api.data.SaveScoreInput;
 import io.spoud.api.data.SeasonTO;
 import io.spoud.entities.MatchEO;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @QuarkusTest
 class MatchResourceTest {
@@ -24,6 +26,9 @@ class MatchResourceTest {
 
   @Inject
   SeasonResource seasonResource;
+
+  @Inject
+  PlayerResource playerResource;
 
   private static final List<UUID> SEED_PLAYER_UUIDS = List.of(
     UUID.fromString("f7ec8a9c-09d6-11ea-8d71-362b9e155667"),
@@ -99,5 +104,60 @@ class MatchResourceTest {
     assertThat(matchResource.lastMaches(seasonOne.uuid())).hasSize(1);
     assertThat(matchResource.lastMaches(seasonTwo.uuid())).hasSize(1);
     assertThat(matchResource.lastMaches(null)).hasSize(2);
+  }
+
+  @Test
+  void should_reject_starting_a_match_when_no_active_season() {
+    assertThatThrownBy(() -> matchResource.startMatchWithPlayers(SEED_PLAYER_UUIDS))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void should_start_a_match_when_a_season_is_active() {
+    seasonResource.createSeason("Season One");
+
+    MatchTO match = matchResource.startMatchWithPlayers(SEED_PLAYER_UUIDS);
+
+    assertThat(match).isNotNull();
+  }
+
+  @Test
+  void should_compute_season_ranking_by_replaying_matches() {
+    SeasonTO season = seasonResource.createSeason("Season One");
+    matchResource.finishMatch(sampleScore());
+
+    List<PlayerTO> ranking = playerResource.seasonRanking(season.uuid());
+
+    assertThat(ranking).hasSize(4);
+    // blue (defense=Anna, offense=Marcel) won 7-1 over red (defense=Gaetan, offense=Julian)
+    assertThat(findPlayer(ranking, "b480ac12-00c5-11ea-8d71-362b9e155667").defensePoints())
+        .isEqualTo(520);
+    assertThat(findPlayer(ranking, "b480a9a6-00c5-11ea-8d71-362b9e155667").offensePoints())
+        .isEqualTo(520);
+    assertThat(findPlayer(ranking, "f7ec8a9c-09d6-11ea-8d71-362b9e155667").defensePoints())
+        .isEqualTo(485);
+    assertThat(findPlayer(ranking, "b480afb4-00c5-11ea-8d71-362b9e155667").offensePoints())
+        .isEqualTo(485);
+  }
+
+  @Test
+  void should_preserve_past_season_ranking_after_a_new_season_resets_live_points() {
+    SeasonTO seasonOne = seasonResource.createSeason("Season One");
+    matchResource.finishMatch(sampleScore());
+
+    seasonResource.createSeason("Season Two");
+
+    List<PlayerTO> pastRanking = playerResource.seasonRanking(seasonOne.uuid());
+    assertThat(findPlayer(pastRanking, "b480ac12-00c5-11ea-8d71-362b9e155667").defensePoints())
+        .isEqualTo(520);
+    assertThat(playerResource.findAll())
+        .allSatisfy(p -> assertThat(p.defensePoints()).isEqualTo(500));
+  }
+
+  private PlayerTO findPlayer(List<PlayerTO> players, String uuid) {
+    return players.stream()
+        .filter(p -> p.uuid().equals(UUID.fromString(uuid)))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/backend/src/test/java/io/spoud/api/MatchResourceTest.java
+++ b/backend/src/test/java/io/spoud/api/MatchResourceTest.java
@@ -3,7 +3,10 @@ package io.spoud.api;
 import io.quarkus.test.junit.QuarkusTest;
 import io.spoud.api.data.MatchTO;
 import io.spoud.api.data.SaveScoreInput;
+import io.spoud.api.data.SeasonTO;
 import io.spoud.entities.MatchEO;
+import io.spoud.entities.PlayerEO;
+import io.spoud.entities.SeasonEO;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.AfterEach;
@@ -19,27 +22,43 @@ class MatchResourceTest {
   @Inject
   MatchResource matchResource;
 
+  @Inject
+  SeasonResource seasonResource;
+
+  private static final List<UUID> SEED_PLAYER_UUIDS = List.of(
+    UUID.fromString("f7ec8a9c-09d6-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480afb4-00c5-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480ac12-00c5-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480a9a6-00c5-11ea-8d71-362b9e155667"));
+
   @AfterEach
   @Transactional
   void cleanup() {
     MatchEO.deleteAll();
+    SeasonEO.deleteAll();
+    PlayerEO.update(
+        "offensePoints = 500, defensePoints = 500 where uuid in ?1", SEED_PLAYER_UUIDS);
   }
 
-  @Test
-  void should_return_empty_matches() {
-    List matches = matchResource.lastMaches();
-    assertThat(matches).isEmpty();
-  }
-
-  @Test
-  void should_save_a_match() {
-    SaveScoreInput score = new SaveScoreInput(
+  private SaveScoreInput sampleScore() {
+    return new SaveScoreInput(
       1,
       7,
       UUID.fromString("f7ec8a9c-09d6-11ea-8d71-362b9e155667"),
       UUID.fromString("b480afb4-00c5-11ea-8d71-362b9e155667"),
       UUID.fromString("b480ac12-00c5-11ea-8d71-362b9e155667"),
       UUID.fromString("b480a9a6-00c5-11ea-8d71-362b9e155667"));
+  }
+
+  @Test
+  void should_return_empty_matches() {
+    List<MatchTO> matches = matchResource.lastMaches(null);
+    assertThat(matches).isEmpty();
+  }
+
+  @Test
+  void should_save_a_match() {
+    SaveScoreInput score = sampleScore();
 
     MatchTO saved = matchResource.finishMatch(score);
 
@@ -53,4 +72,32 @@ class MatchResourceTest {
     assertThat(saved.playerBlueOffenseUuid()).isEqualTo(score.playerBlueOffenseUuid());
   }
 
+  @Test
+  void should_leave_match_unassigned_when_no_active_season() {
+    matchResource.finishMatch(sampleScore());
+
+    assertThat(matchResource.lastMaches(null)).hasSize(1);
+  }
+
+  @Test
+  void should_tag_new_matches_with_the_active_season() {
+    SeasonTO season = seasonResource.createSeason("Spring 2026");
+
+    matchResource.finishMatch(sampleScore());
+
+    assertThat(matchResource.lastMaches(season.uuid())).hasSize(1);
+  }
+
+  @Test
+  void should_filter_matches_by_season() {
+    SeasonTO seasonOne = seasonResource.createSeason("Season One");
+    matchResource.finishMatch(sampleScore());
+
+    SeasonTO seasonTwo = seasonResource.createSeason("Season Two");
+    matchResource.finishMatch(sampleScore());
+
+    assertThat(matchResource.lastMaches(seasonOne.uuid())).hasSize(1);
+    assertThat(matchResource.lastMaches(seasonTwo.uuid())).hasSize(1);
+    assertThat(matchResource.lastMaches(null)).hasSize(2);
+  }
 }

--- a/backend/src/test/java/io/spoud/api/SeasonResourceTest.java
+++ b/backend/src/test/java/io/spoud/api/SeasonResourceTest.java
@@ -1,0 +1,86 @@
+package io.spoud.api;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.spoud.api.data.SeasonTO;
+import io.spoud.entities.SeasonEO;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+class SeasonResourceTest {
+
+  @Inject
+  SeasonResource seasonResource;
+
+  @AfterEach
+  @Transactional
+  void cleanup() {
+    SeasonEO.deleteAll();
+  }
+
+  @Test
+  void should_create_a_season() {
+    SeasonTO season = seasonResource.createSeason("Spring 2026");
+
+    assertThat(season.uuid()).isNotNull();
+    assertThat(season.label()).isEqualTo("Spring 2026");
+    assertThat(season.startTime()).isNotNull();
+    assertThat(season.endTime()).isNull();
+  }
+
+  @Test
+  void should_auto_close_the_previous_active_season_when_starting_a_new_one() {
+    SeasonTO first = seasonResource.createSeason("Season One");
+
+    SeasonTO second = seasonResource.createSeason("Season Two");
+
+    List<SeasonTO> seasons = seasonResource.allSeasons();
+    SeasonTO firstAfter =
+        seasons.stream().filter(s -> s.uuid().equals(first.uuid())).findFirst().orElseThrow();
+    SeasonTO secondAfter =
+        seasons.stream().filter(s -> s.uuid().equals(second.uuid())).findFirst().orElseThrow();
+    assertThat(firstAfter.endTime()).isNotNull();
+    assertThat(secondAfter.endTime()).isNull();
+  }
+
+  @Test
+  void should_close_a_season() {
+    SeasonTO season = seasonResource.createSeason("Season One");
+
+    boolean closed = seasonResource.closeSeason(season.uuid());
+
+    assertThat(closed).isTrue();
+    assertThat(seasonResource.allSeasons().get(0).endTime()).isNotNull();
+  }
+
+  @Test
+  void should_return_false_when_closing_unknown_season() {
+    assertThat(seasonResource.closeSeason(UUID.randomUUID())).isFalse();
+  }
+
+  @Test
+  void should_return_false_when_closing_an_already_closed_season() {
+    SeasonTO season = seasonResource.createSeason("Season One");
+    seasonResource.closeSeason(season.uuid());
+
+    assertThat(seasonResource.closeSeason(season.uuid())).isFalse();
+  }
+
+  @Test
+  void should_list_seasons_newest_first() {
+    seasonResource.createSeason("Season One");
+    seasonResource.createSeason("Season Two");
+
+    List<SeasonTO> seasons = seasonResource.allSeasons();
+
+    assertThat(seasons).hasSize(2);
+    assertThat(seasons.get(0).label()).isEqualTo("Season Two");
+  }
+}

--- a/backend/src/test/java/io/spoud/api/SeasonResourceTest.java
+++ b/backend/src/test/java/io/spoud/api/SeasonResourceTest.java
@@ -2,6 +2,7 @@ package io.spoud.api;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.spoud.api.data.SeasonTO;
+import io.spoud.entities.PlayerEO;
 import io.spoud.entities.SeasonEO;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -16,6 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @QuarkusTest
 class SeasonResourceTest {
 
+  private static final List<UUID> SEED_PLAYER_UUIDS = List.of(
+    UUID.fromString("f7ec8a9c-09d6-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480afb4-00c5-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480ac12-00c5-11ea-8d71-362b9e155667"),
+    UUID.fromString("b480a9a6-00c5-11ea-8d71-362b9e155667"));
+
   @Inject
   SeasonResource seasonResource;
 
@@ -23,6 +30,8 @@ class SeasonResourceTest {
   @Transactional
   void cleanup() {
     SeasonEO.deleteAll();
+    PlayerEO.update(
+        "offensePoints = 500, defensePoints = 500 where uuid in ?1", SEED_PLAYER_UUIDS);
   }
 
   @Test
@@ -82,5 +91,18 @@ class SeasonResourceTest {
 
     assertThat(seasons).hasSize(2);
     assertThat(seasons.get(0).label()).isEqualTo("Season Two");
+  }
+
+  @Test
+  @Transactional
+  void should_reset_player_points_when_starting_a_new_season() {
+    UUID playerUuid = SEED_PLAYER_UUIDS.get(0);
+    PlayerEO.update("offensePoints = 700, defensePoints = 300 where uuid = ?1", playerUuid);
+
+    seasonResource.createSeason("Season One");
+
+    PlayerEO after = PlayerEO.findById(playerUuid);
+    assertThat(after.offensePoints).isEqualTo(500);
+    assertThat(after.defensePoints).isEqualTo(500);
   }
 }

--- a/frontend/graphql/schema.graphql
+++ b/frontend/graphql/schema.graphql
@@ -37,6 +37,7 @@ type Query {
   allSeasons: [Season!]!
   archivedPlayers: [Player!]!
   lastMatches(seasonUuid: String): [Match!]!
+  seasonRanking(seasonUuid: String!): [Player!]!
 }
 
 type Season {

--- a/frontend/graphql/schema.graphql
+++ b/frontend/graphql/schema.graphql
@@ -13,7 +13,9 @@ type Match {
 
 "Mutation root"
 type Mutation {
+  closeSeason(uuid: String!): Boolean!
   createPlayer(nickName: String!): Player!
+  createSeason(label: String!): Season!
   deletePlayer(uuid: String!): Boolean!
   randomizeMatch(players: [String!]!): Match!
   saveScore(scores: SaveScoreInput!): Match!
@@ -32,8 +34,18 @@ type Player {
 "Query root"
 type Query {
   allPlayers: [Player!]!
+  allSeasons: [Season!]!
   archivedPlayers: [Player!]!
-  lastMatches: [Match!]!
+  lastMatches(seasonUuid: String): [Match!]!
+}
+
+type Season {
+  "ISO-8601"
+  endTime: DateTime
+  label: String!
+  "ISO-8601"
+  startTime: DateTime!
+  uuid: String!
 }
 
 type Team {

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import {CurrentMatchComponent} from "./current-match/current-match.component";
 import {ScoreboardComponent} from "./scoreboard/scoreboard.component";
 import {ManagePlayersComponent} from "./manage-players/manage-players.component";
 import {ManageSeasonsComponent} from "./manage-seasons/manage-seasons.component";
+import {HistoryComponent} from "./history/history.component";
 
 export const routes: Routes = [
   {path: 'players-selection', component: PlayersSelectionComponent},
@@ -11,6 +12,7 @@ export const routes: Routes = [
   {path: 'scoreboard', component: ScoreboardComponent},
   {path: 'manage-players', component: ManagePlayersComponent},
   {path: 'manage-seasons', component: ManageSeasonsComponent},
+  {path: 'history', component: HistoryComponent},
   {
     path: '',
     redirectTo: '/scoreboard',

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,12 +3,14 @@ import {PlayersSelectionComponent} from "./players-selection/players-selection.c
 import {CurrentMatchComponent} from "./current-match/current-match.component";
 import {ScoreboardComponent} from "./scoreboard/scoreboard.component";
 import {ManagePlayersComponent} from "./manage-players/manage-players.component";
+import {ManageSeasonsComponent} from "./manage-seasons/manage-seasons.component";
 
 export const routes: Routes = [
   {path: 'players-selection', component: PlayersSelectionComponent},
   {path: 'current-match', component: CurrentMatchComponent},
   {path: 'scoreboard', component: ScoreboardComponent},
   {path: 'manage-players', component: ManagePlayersComponent},
+  {path: 'manage-seasons', component: ManageSeasonsComponent},
   {
     path: '',
     redirectTo: '/scoreboard',

--- a/frontend/src/app/history/history.component.html
+++ b/frontend/src/app/history/history.component.html
@@ -1,14 +1,25 @@
-<h1>History</h1>
+<div class="jumbotron">
+  <h1 class="display-3">History</h1>
+  <p class="lead">
+    <label for="season-filter-select">Season</label>
+    <select id="season-filter-select" class="form-select d-inline-block w-auto" (change)="onSeasonFilterChange($event)">
+      <option value="">All seasons</option>
+      @for (season of seasons(); track season.uuid) {
+        <option [value]="season.uuid">{{ season.label }}</option>
+      }
+    </select>
+  </p>
+</div>
 
 <div class="container-fluid">
   <div class="row">
     <div class="col-md-6">
       <h2>Ranking</h2>
-      <app-players-scoreboard></app-players-scoreboard>
+      <app-players-scoreboard [seasonUuid]="selectedSeasonUuid()"></app-players-scoreboard>
     </div>
     <div class="col-md-6">
       <h2>Matches</h2>
-      <app-last-matches></app-last-matches>
+      <app-last-matches [seasonUuid]="selectedSeasonUuid()"></app-last-matches>
     </div>
   </div>
 </div>

--- a/frontend/src/app/history/history.component.html
+++ b/frontend/src/app/history/history.component.html
@@ -1,0 +1,9 @@
+<h1>Match history</h1>
+
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-8">
+      <app-last-matches></app-last-matches>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/history/history.component.html
+++ b/frontend/src/app/history/history.component.html
@@ -1,25 +1,30 @@
 <div class="jumbotron">
   <h1 class="display-3">History</h1>
-  <p class="lead">
-    <label for="season-filter-select">Season</label>
-    <select id="season-filter-select" class="form-select d-inline-block w-auto" (change)="onSeasonFilterChange($event)">
-      <option value="">All seasons</option>
-      @for (season of seasons(); track season.uuid) {
-        <option [value]="season.uuid">{{ season.label }}</option>
-      }
-    </select>
-  </p>
+  @if (hasSeasons()) {
+    <p class="lead">
+      <label for="season-filter-select">Season</label>
+      <select id="season-filter-select" class="form-select d-inline-block w-auto" [value]="selectedSeasonUuid()" (change)="onSeasonFilterChange($event)">
+        @for (season of seasons(); track season.uuid) {
+          <option [value]="season.uuid">{{ season.label }}</option>
+        }
+      </select>
+    </p>
+  } @else {
+    <p class="lead">No seasons yet — create one on the Manage seasons page.</p>
+  }
 </div>
 
-<div class="container-fluid">
-  <div class="row">
-    <div class="col-md-6">
-      <h2>Ranking</h2>
-      <app-players-scoreboard [seasonUuid]="selectedSeasonUuid()"></app-players-scoreboard>
-    </div>
-    <div class="col-md-6">
-      <h2>Matches</h2>
-      <app-last-matches [seasonUuid]="selectedSeasonUuid()"></app-last-matches>
+@if (hasSeasons()) {
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-6">
+        <h2>Ranking</h2>
+        <app-players-scoreboard [seasonUuid]="selectedSeasonUuid()"></app-players-scoreboard>
+      </div>
+      <div class="col-md-6">
+        <h2>Matches</h2>
+        <app-last-matches [seasonUuid]="selectedSeasonUuid()"></app-last-matches>
+      </div>
     </div>
   </div>
-</div>
+}

--- a/frontend/src/app/history/history.component.html
+++ b/frontend/src/app/history/history.component.html
@@ -1,8 +1,13 @@
-<h1>Match history</h1>
+<h1>History</h1>
 
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-8">
+    <div class="col-md-6">
+      <h2>Ranking</h2>
+      <app-players-scoreboard></app-players-scoreboard>
+    </div>
+    <div class="col-md-6">
+      <h2>Matches</h2>
       <app-last-matches></app-last-matches>
     </div>
   </div>

--- a/frontend/src/app/history/history.component.ts
+++ b/frontend/src/app/history/history.component.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+import {LastMatchesComponent} from "../scoreboard/last-matches/last-matches.component";
+
+@Component({
+  selector: 'app-history',
+  templateUrl: './history.component.html',
+  styleUrl: './history.component.scss',
+  imports: [
+    LastMatchesComponent
+  ]
+})
+export class HistoryComponent {
+}

--- a/frontend/src/app/history/history.component.ts
+++ b/frontend/src/app/history/history.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, signal} from '@angular/core';
+import {Component, computed, effect, inject, signal} from '@angular/core';
 import {LastMatchesComponent} from "../scoreboard/last-matches/last-matches.component";
 import {PlayersScoreboardComponent} from "../scoreboard/players-scoreboard/players-scoreboard.component";
 import {SeasonsService} from "../services/seasons-service";
@@ -18,9 +18,26 @@ export class HistoryComponent {
 
   public seasons = this.seasonsService.seasons;
   public selectedSeasonUuid = signal<string | undefined>(undefined);
+  public hasSeasons = computed(() => this.seasons().length > 0);
+
+  constructor() {
+    // There's no meaningful "all seasons combined" ranking (live points are
+    // just the current season's, since they reset each season), so this
+    // page always shows one specific season's data - default to the active
+    // one, or the most recent if none is active, rather than leaving it
+    // unselected.
+    effect(() => {
+      if (this.selectedSeasonUuid() === undefined) {
+        const seasons = this.seasonsService.seasons();
+        const defaultSeason = seasons.find(s => !s.endTime) ?? seasons[0];
+        if (defaultSeason) {
+          this.selectedSeasonUuid.set(defaultSeason.uuid);
+        }
+      }
+    });
+  }
 
   public onSeasonFilterChange(event: Event): void {
-    const value = (event.target as HTMLSelectElement).value;
-    this.selectedSeasonUuid.set(value ? value : undefined);
+    this.selectedSeasonUuid.set((event.target as HTMLSelectElement).value);
   }
 }

--- a/frontend/src/app/history/history.component.ts
+++ b/frontend/src/app/history/history.component.ts
@@ -1,6 +1,7 @@
-import {Component} from '@angular/core';
+import {Component, inject, signal} from '@angular/core';
 import {LastMatchesComponent} from "../scoreboard/last-matches/last-matches.component";
 import {PlayersScoreboardComponent} from "../scoreboard/players-scoreboard/players-scoreboard.component";
+import {SeasonsService} from "../services/seasons-service";
 
 @Component({
   selector: 'app-history',
@@ -12,4 +13,14 @@ import {PlayersScoreboardComponent} from "../scoreboard/players-scoreboard/playe
   ]
 })
 export class HistoryComponent {
+
+  private seasonsService = inject(SeasonsService);
+
+  public seasons = this.seasonsService.seasons;
+  public selectedSeasonUuid = signal<string | undefined>(undefined);
+
+  public onSeasonFilterChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.selectedSeasonUuid.set(value ? value : undefined);
+  }
 }

--- a/frontend/src/app/history/history.component.ts
+++ b/frontend/src/app/history/history.component.ts
@@ -1,12 +1,14 @@
 import {Component} from '@angular/core';
 import {LastMatchesComponent} from "../scoreboard/last-matches/last-matches.component";
+import {PlayersScoreboardComponent} from "../scoreboard/players-scoreboard/players-scoreboard.component";
 
 @Component({
   selector: 'app-history',
   templateUrl: './history.component.html',
   styleUrl: './history.component.scss',
   imports: [
-    LastMatchesComponent
+    LastMatchesComponent,
+    PlayersScoreboardComponent
   ]
 })
 export class HistoryComponent {

--- a/frontend/src/app/manage-seasons/manage-seasons.component.html
+++ b/frontend/src/app/manage-seasons/manage-seasons.component.html
@@ -1,0 +1,46 @@
+<div class="jumbotron">
+  <h1 class="display-3">Manage seasons</h1>
+  <p class="lead">
+    <input type="text"
+           class="form-control d-inline-block"
+           placeholder="New season label"
+           [value]="newSeasonLabel()"
+           (input)="onNewSeasonLabelInput($event)"
+           (keydown.enter)="startSeason()"/>
+    <button type="button" class="btn btn-primary btn-lg" [disabled]="!newSeasonLabel().trim()"
+            (click)="startSeason()">Start season
+    </button>
+  </p>
+  <p class="text-muted">Starting a new season automatically closes the currently active one.</p>
+</div>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">Label</th>
+      <th scope="col">Start</th>
+      <th scope="col">End</th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (season of seasons(); track season.uuid) {
+      <tr>
+        <td>{{ season.label }}</td>
+        <td>{{ season.startTime | date: 'dd.MM.yyyy H:mm' }}</td>
+        <td>
+          @if (season.endTime) {
+            {{ season.endTime | date: 'dd.MM.yyyy H:mm' }}
+          } @else {
+            <span class="badge bg-success">Active</span>
+          }
+        </td>
+        <td>
+          @if (!season.endTime) {
+            <button type="button" class="btn btn-outline-danger btn-sm" (click)="closeSeason(season.uuid)">Close</button>
+          }
+        </td>
+      </tr>
+    }
+  </tbody>
+</table>

--- a/frontend/src/app/manage-seasons/manage-seasons.component.ts
+++ b/frontend/src/app/manage-seasons/manage-seasons.component.ts
@@ -1,0 +1,35 @@
+import {Component, inject, signal} from '@angular/core';
+import {DatePipe} from "@angular/common";
+import {SeasonsService} from "../services/seasons-service";
+
+@Component({
+  selector: 'app-manage-seasons',
+  templateUrl: './manage-seasons.component.html',
+  styleUrl: './manage-seasons.component.scss',
+  imports: [
+    DatePipe
+  ]
+})
+export class ManageSeasonsComponent {
+
+  private seasonsService = inject(SeasonsService);
+
+  public seasons = this.seasonsService.seasons;
+  public newSeasonLabel = signal('');
+
+  public onNewSeasonLabelInput(event: Event): void {
+    this.newSeasonLabel.set((event.target as HTMLInputElement).value);
+  }
+
+  public startSeason(): void {
+    const label = this.newSeasonLabel().trim();
+    if (label) {
+      this.seasonsService.createSeason(label);
+      this.newSeasonLabel.set('');
+    }
+  }
+
+  public closeSeason(uuid: string): void {
+    this.seasonsService.closeSeason(uuid);
+  }
+}

--- a/frontend/src/app/nav/nav.component.ts
+++ b/frontend/src/app/nav/nav.component.ts
@@ -20,6 +20,7 @@ export class NavComponent {
 
   public links: NavLink[] = [
     {label: 'Scoreboard', path: '/scoreboard'},
+    {label: 'History', path: '/history'},
     {label: 'Manage players', path: '/manage-players'},
     {label: 'Manage seasons', path: '/manage-seasons'},
   ];

--- a/frontend/src/app/nav/nav.component.ts
+++ b/frontend/src/app/nav/nav.component.ts
@@ -21,6 +21,7 @@ export class NavComponent {
   public links: NavLink[] = [
     {label: 'Scoreboard', path: '/scoreboard'},
     {label: 'Manage players', path: '/manage-players'},
+    {label: 'Manage seasons', path: '/manage-seasons'},
   ];
 
   public isCollapsed = signal(true);

--- a/frontend/src/app/players-selection/players-selection.component.css
+++ b/frontend/src/app/players-selection/players-selection.component.css
@@ -1,7 +1,10 @@
 div.jumbotron {
   margin: auto;
-  text-align: center;
   padding: 5px;
+}
+
+.jumbotron .lead {
+  text-align: center;
 }
 
 .lead button{

--- a/frontend/src/app/players-selection/players-selection.component.html
+++ b/frontend/src/app/players-selection/players-selection.component.html
@@ -1,5 +1,8 @@
 <div class="jumbotron">
   <h1 class="display-3">Who's in ?</h1>
+  @if (!hasActiveSeason()) {
+    <p class="lead text-danger">No active season — start one on the Manage seasons page before playing.</p>
+  }
   <p class="lead">{{playerCount()}} Players selected </p>
   <p class="lead">
     @if (sortByName()) {
@@ -8,7 +11,7 @@
       <button type="button" class="btn btn-secondary btn-lg" (click)="sortByName.set(true)">Sort by name</button>
     }
     <button type="button" class="btn btn-secondary btn-lg" routerLink="scoreboard">Cancel</button>
-    <button type="button" class="btn btn-primary btn-lg" [disabled]="!enoughToStart()" (click)="startMatch()">Start</button>
+    <button type="button" class="btn btn-primary btn-lg" [disabled]="!canStart()" (click)="startMatch()">Start</button>
   </p>
 </div>
 

--- a/frontend/src/app/players-selection/players-selection.component.ts
+++ b/frontend/src/app/players-selection/players-selection.component.ts
@@ -5,6 +5,7 @@ import {RouterModule} from "@angular/router";
 import {PlayersService} from "../services/players-service";
 import {Player} from "../../generated/graphql";
 import {MatchesService} from "../services/matches-service";
+import {SeasonsService} from "../services/seasons-service";
 
 @Component({
   selector: 'app-players-selection',
@@ -19,6 +20,7 @@ export class PlayersSelectionComponent {
 
   private playersService = inject(PlayersService);
   private matchService = inject(MatchesService);
+  private seasonsService = inject(SeasonsService);
 
   sortByName = signal<boolean>(false);
   players = computed(() => {
@@ -30,6 +32,8 @@ export class PlayersSelectionComponent {
   selectedPlayers = signal(new Set<string>());
   playerCount = computed(() => this.selectedPlayers().size);
   enoughToStart = computed(() => this.playerCount() >= 4);
+  hasActiveSeason = computed(() => !!this.seasonsService.activeSeason());
+  canStart = computed(() => this.enoughToStart() && this.hasActiveSeason());
 
   public selectPlayer(player: Player) {
     this.selectedPlayers.update(list => {

--- a/frontend/src/app/scoreboard/last-matches/last-matches.component.html
+++ b/frontend/src/app/scoreboard/last-matches/last-matches.component.html
@@ -1,3 +1,13 @@
+<div class="season-filter mb-2">
+  <label for="season-filter-select">Season</label>
+  <select id="season-filter-select" class="form-select d-inline-block w-auto" (change)="onSeasonFilterChange($event)">
+    <option value="">All seasons</option>
+    @for (season of seasons(); track season.uuid) {
+      <option [value]="season.uuid">{{ season.label }}</option>
+    }
+  </select>
+</div>
+
 <table class="table table-striped">
   <thead>
     <tr>

--- a/frontend/src/app/scoreboard/last-matches/last-matches.component.html
+++ b/frontend/src/app/scoreboard/last-matches/last-matches.component.html
@@ -1,15 +1,3 @@
-@if (showSeasonFilter()) {
-  <div class="season-filter mb-2">
-    <label for="season-filter-select">Season</label>
-    <select id="season-filter-select" class="form-select d-inline-block w-auto" (change)="onSeasonFilterChange($event)">
-      <option value="">All seasons</option>
-      @for (season of seasons(); track season.uuid) {
-        <option [value]="season.uuid">{{ season.label }}</option>
-      }
-    </select>
-  </div>
-}
-
 <table class="table table-striped">
   <thead>
     <tr>

--- a/frontend/src/app/scoreboard/last-matches/last-matches.component.html
+++ b/frontend/src/app/scoreboard/last-matches/last-matches.component.html
@@ -1,12 +1,14 @@
-<div class="season-filter mb-2">
-  <label for="season-filter-select">Season</label>
-  <select id="season-filter-select" class="form-select d-inline-block w-auto" (change)="onSeasonFilterChange($event)">
-    <option value="">All seasons</option>
-    @for (season of seasons(); track season.uuid) {
-      <option [value]="season.uuid">{{ season.label }}</option>
-    }
-  </select>
-</div>
+@if (showSeasonFilter()) {
+  <div class="season-filter mb-2">
+    <label for="season-filter-select">Season</label>
+    <select id="season-filter-select" class="form-select d-inline-block w-auto" (change)="onSeasonFilterChange($event)">
+      <option value="">All seasons</option>
+      @for (season of seasons(); track season.uuid) {
+        <option [value]="season.uuid">{{ season.label }}</option>
+      }
+    </select>
+  </div>
+}
 
 <table class="table table-striped">
   <thead>

--- a/frontend/src/app/scoreboard/last-matches/last-matches.component.ts
+++ b/frontend/src/app/scoreboard/last-matches/last-matches.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, inject, ViewChild} from '@angular/core';
+import {Component, computed, effect, inject, input, ViewChild} from '@angular/core';
 import {CommonModule, DatePipe} from "@angular/common";
 import {MatchesService} from "../../services/matches-service";
 import {SeasonsService} from "../../services/seasons-service";
@@ -40,6 +40,7 @@ export class LastMatchesComponent {
   private matchesService = inject(MatchesService);
   private seasonsService = inject(SeasonsService);
 
+  public mode = input<'current' | 'browse'>('browse');
 
   @ViewChild('rematchRef')
   private rematchModal?: RematchModalComponent;
@@ -49,6 +50,17 @@ export class LastMatchesComponent {
   });
 
   public seasons = this.seasonsService.seasons;
+  public showSeasonFilter = computed(() => this.mode() === 'browse');
+
+  constructor() {
+    effect(() => {
+      if (this.mode() === 'current') {
+        this.matchesService.filterBySeason(this.seasonsService.activeSeason()?.uuid);
+      } else {
+        this.matchesService.filterBySeason(undefined);
+      }
+    });
+  }
 
   public onSeasonFilterChange(event: Event): void {
     const value = (event.target as HTMLSelectElement).value;

--- a/frontend/src/app/scoreboard/last-matches/last-matches.component.ts
+++ b/frontend/src/app/scoreboard/last-matches/last-matches.component.ts
@@ -1,7 +1,6 @@
 import {Component, computed, effect, inject, input, ViewChild} from '@angular/core';
 import {CommonModule, DatePipe} from "@angular/common";
 import {MatchesService} from "../../services/matches-service";
-import {SeasonsService} from "../../services/seasons-service";
 import {Match, Team} from "../../../generated/graphql";
 import {RematchModalComponent} from "../rematch-modal/rematch-modal.component";
 
@@ -38,9 +37,8 @@ export class MatchWithWinnerLooser {
 })
 export class LastMatchesComponent {
   private matchesService = inject(MatchesService);
-  private seasonsService = inject(SeasonsService);
 
-  public mode = input<'current' | 'browse'>('browse');
+  public seasonUuid = input<string | undefined>(undefined);
 
   @ViewChild('rematchRef')
   private rematchModal?: RematchModalComponent;
@@ -49,22 +47,10 @@ export class LastMatchesComponent {
     return this.matchesService.lastMatches().map(m => new MatchWithWinnerLooser(m));
   });
 
-  public seasons = this.seasonsService.seasons;
-  public showSeasonFilter = computed(() => this.mode() === 'browse');
-
   constructor() {
     effect(() => {
-      if (this.mode() === 'current') {
-        this.matchesService.filterBySeason(this.seasonsService.activeSeason()?.uuid);
-      } else {
-        this.matchesService.filterBySeason(undefined);
-      }
+      this.matchesService.filterBySeason(this.seasonUuid());
     });
-  }
-
-  public onSeasonFilterChange(event: Event): void {
-    const value = (event.target as HTMLSelectElement).value;
-    this.matchesService.filterBySeason(value ? value : undefined);
   }
 
   public rematch(match: Match) {

--- a/frontend/src/app/scoreboard/last-matches/last-matches.component.ts
+++ b/frontend/src/app/scoreboard/last-matches/last-matches.component.ts
@@ -1,6 +1,7 @@
 import {Component, computed, inject, ViewChild} from '@angular/core';
 import {CommonModule, DatePipe} from "@angular/common";
 import {MatchesService} from "../../services/matches-service";
+import {SeasonsService} from "../../services/seasons-service";
 import {Match, Team} from "../../../generated/graphql";
 import {RematchModalComponent} from "../rematch-modal/rematch-modal.component";
 
@@ -37,6 +38,7 @@ export class MatchWithWinnerLooser {
 })
 export class LastMatchesComponent {
   private matchesService = inject(MatchesService);
+  private seasonsService = inject(SeasonsService);
 
 
   @ViewChild('rematchRef')
@@ -45,6 +47,13 @@ export class LastMatchesComponent {
   public matches = computed(() => {
     return this.matchesService.lastMatches().map(m => new MatchWithWinnerLooser(m));
   });
+
+  public seasons = this.seasonsService.seasons;
+
+  public onSeasonFilterChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.matchesService.filterBySeason(value ? value : undefined);
+  }
 
   public rematch(match: Match) {
     this.rematchModal?.rematch(match);

--- a/frontend/src/app/scoreboard/players-scoreboard/players-scoreboard.component.ts
+++ b/frontend/src/app/scoreboard/players-scoreboard/players-scoreboard.component.ts
@@ -1,7 +1,8 @@
-import {Component, computed, inject} from '@angular/core';
+import {Component, computed, effect, inject, input, signal} from '@angular/core';
 import {SpoudAvatarComponent} from "../../spoud-avatar/spoud-avatar.component";
 import {LastMatchTimePipe} from "./last-match-time.pipe";
 import {PlayersService} from "../../services/players-service";
+import {Player} from "../../../generated/graphql";
 
 
 @Component({
@@ -17,7 +18,26 @@ export class PlayersScoreboardComponent {
 
   private playersService = inject(PlayersService);
 
-  public players = computed(() => this.playersService.players()
-    .filter(p => p.lastMatchTime));
+  public seasonUuid = input<string | undefined>(undefined);
+
+  private seasonRanking = signal<Player[]>([]);
+
+  public players = computed(() => {
+    if (!this.seasonUuid()) {
+      return this.playersService.players().filter(p => p.lastMatchTime);
+    }
+    return this.seasonRanking()
+      .slice()
+      .sort((l, r) => (r.defensePoints + r.offensePoints) - (l.defensePoints + l.offensePoints));
+  });
+
+  constructor() {
+    effect(() => {
+      const seasonUuid = this.seasonUuid();
+      if (seasonUuid) {
+        this.playersService.fetchSeasonRanking(seasonUuid).subscribe(players => this.seasonRanking.set(players));
+      }
+    });
+  }
 
 }

--- a/frontend/src/app/scoreboard/scoreboard.component.css
+++ b/frontend/src/app/scoreboard/scoreboard.component.css
@@ -1,7 +1,0 @@
-h1{
-  text-align: center;
-}
-.start-game-container{
-  margin: 10px;
-  text-align: center;
-}

--- a/frontend/src/app/scoreboard/scoreboard.component.html
+++ b/frontend/src/app/scoreboard/scoreboard.component.html
@@ -1,4 +1,4 @@
-<h1>Score board</h1>
+<h1>{{ heading() }}</h1>
 <div class="start-game-container">
   <button type="button" class="btn btn-primary btn-lg" routerLink="/players-selection">Start a game</button>
 </div>
@@ -7,6 +7,9 @@
   <div class="row">
     <div class="col-md-6">
       <app-players-scoreboard></app-players-scoreboard>
+    </div>
+    <div class="col-md-6">
+      <app-last-matches mode="current"></app-last-matches>
     </div>
   </div>
 </div>

--- a/frontend/src/app/scoreboard/scoreboard.component.html
+++ b/frontend/src/app/scoreboard/scoreboard.component.html
@@ -1,6 +1,11 @@
-<h1>{{ heading() }}</h1>
-<div class="start-game-container">
-  <button type="button" class="btn btn-primary btn-lg" routerLink="/players-selection">Start a game</button>
+<div class="jumbotron">
+  <h1 class="display-3">{{ heading() }}</h1>
+  @if (!hasActiveSeason()) {
+    <p class="lead text-danger">No active season — start one on the Manage seasons page before playing.</p>
+  }
+  <p class="lead">
+    <button type="button" class="btn btn-primary btn-lg" [disabled]="!hasActiveSeason()" routerLink="/players-selection">Start a game</button>
+  </p>
 </div>
 
 <div class="container-fluid">
@@ -9,7 +14,7 @@
       <app-players-scoreboard></app-players-scoreboard>
     </div>
     <div class="col-md-6">
-      <app-last-matches mode="current"></app-last-matches>
+      <app-last-matches [seasonUuid]="activeSeasonUuid()"></app-last-matches>
     </div>
   </div>
 </div>

--- a/frontend/src/app/scoreboard/scoreboard.component.html
+++ b/frontend/src/app/scoreboard/scoreboard.component.html
@@ -8,8 +8,5 @@
     <div class="col-md-6">
       <app-players-scoreboard></app-players-scoreboard>
     </div>
-    <div class="col-md-6">
-      <app-last-matches></app-last-matches>
-    </div>
   </div>
 </div>

--- a/frontend/src/app/scoreboard/scoreboard.component.ts
+++ b/frontend/src/app/scoreboard/scoreboard.component.ts
@@ -1,6 +1,5 @@
 import {Component} from '@angular/core';
 import {PlayersScoreboardComponent} from "./players-scoreboard/players-scoreboard.component";
-import {LastMatchesComponent} from "./last-matches/last-matches.component";
 
 import {RouterModule} from "@angular/router";
 
@@ -10,8 +9,7 @@ import {RouterModule} from "@angular/router";
   styleUrls: ['./scoreboard.component.css'],
   imports: [
     RouterModule,
-    PlayersScoreboardComponent,
-    LastMatchesComponent
+    PlayersScoreboardComponent
   ]
 })
 export class ScoreboardComponent {

--- a/frontend/src/app/scoreboard/scoreboard.component.ts
+++ b/frontend/src/app/scoreboard/scoreboard.component.ts
@@ -1,5 +1,7 @@
-import {Component} from '@angular/core';
+import {Component, computed, inject} from '@angular/core';
 import {PlayersScoreboardComponent} from "./players-scoreboard/players-scoreboard.component";
+import {LastMatchesComponent} from "./last-matches/last-matches.component";
+import {SeasonsService} from "../services/seasons-service";
 
 import {RouterModule} from "@angular/router";
 
@@ -9,9 +11,16 @@ import {RouterModule} from "@angular/router";
   styleUrls: ['./scoreboard.component.css'],
   imports: [
     RouterModule,
-    PlayersScoreboardComponent
+    PlayersScoreboardComponent,
+    LastMatchesComponent
   ]
 })
 export class ScoreboardComponent {
 
+  private seasonsService = inject(SeasonsService);
+
+  public heading = computed(() => {
+    const label = this.seasonsService.activeSeason()?.label;
+    return label ? `Score board (${label})` : 'Score board';
+  });
 }

--- a/frontend/src/app/scoreboard/scoreboard.component.ts
+++ b/frontend/src/app/scoreboard/scoreboard.component.ts
@@ -23,4 +23,7 @@ export class ScoreboardComponent {
     const label = this.seasonsService.activeSeason()?.label;
     return label ? `Score board (${label})` : 'Score board';
   });
+
+  public hasActiveSeason = computed(() => !!this.seasonsService.activeSeason());
+  public activeSeasonUuid = computed(() => this.seasonsService.activeSeason()?.uuid);
 }

--- a/frontend/src/app/services/matches-service.ts
+++ b/frontend/src/app/services/matches-service.ts
@@ -17,18 +17,24 @@ export class MatchesService {
 
   private _lastMatches = signal<Match[]>([]);
   private _currentMatch = signal<Match | undefined>(undefined);
+  private seasonUuid: string | undefined = undefined;
 
   public constructor() {
     this.reloadMatches();
   }
 
   public reloadMatches(): void {
-    this.lastMatchesGql.fetch()
+    this.lastMatchesGql.fetch({variables: {seasonUuid: this.seasonUuid}})
       .pipe(
         map(res => res.data?.lastMatches as Match[]),
         map(list => list.slice().sort((l, r) => r.matchTime.getTime() - l.matchTime.getTime()))
       )
       .subscribe(this._lastMatches.set);
+  }
+
+  public filterBySeason(seasonUuid: string | undefined): void {
+    this.seasonUuid = seasonUuid;
+    this.reloadMatches();
   }
 
   startMatch(playerUuids: string[]) {

--- a/frontend/src/app/services/players-service.ts
+++ b/frontend/src/app/services/players-service.ts
@@ -5,6 +5,7 @@ import {
   CreatePlayerGQL,
   DeletePlayerGQL,
   Player,
+  SeasonRankingGQL,
   UnarchivePlayerGQL
 } from "../../generated/graphql";
 import {map} from "rxjs/operators";
@@ -19,6 +20,7 @@ export class PlayersService {
   private createPlayerGql = inject(CreatePlayerGQL);
   private deletePlayerGql = inject(DeletePlayerGQL);
   private unarchivePlayerGql = inject(UnarchivePlayerGQL);
+  private seasonRankingGql = inject(SeasonRankingGQL);
 
   private _players = signal<Player[]>([]);
   private _archivedPlayers = signal<Player[]>([]);
@@ -36,6 +38,11 @@ export class PlayersService {
           .sort((l, r) => (r.defensePoints + r.offensePoints) - (l.defensePoints + l.offensePoints)))
       )
       .subscribe(this._players.set);
+  }
+
+  public fetchSeasonRanking(seasonUuid: string) {
+    return this.seasonRankingGql.fetch({variables: {seasonUuid}})
+      .pipe(map(res => res.data?.seasonRanking as Player[]));
   }
 
   public reloadArchivedPlayers(): void {

--- a/frontend/src/app/services/seasons-service.ts
+++ b/frontend/src/app/services/seasons-service.ts
@@ -1,0 +1,39 @@
+import {inject, Injectable, Signal, signal} from "@angular/core";
+import {AllSeasonsGQL, CloseSeasonGQL, CreateSeasonGQL, Season} from "../../generated/graphql";
+import {map} from "rxjs/operators";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SeasonsService {
+
+  private allSeasonsGql = inject(AllSeasonsGQL);
+  private createSeasonGql = inject(CreateSeasonGQL);
+  private closeSeasonGql = inject(CloseSeasonGQL);
+
+  private _seasons = signal<Season[]>([]);
+
+  constructor() {
+    this.reloadSeasons();
+  }
+
+  public reloadSeasons(): void {
+    this.allSeasonsGql.fetch()
+      .pipe(map(res => res.data?.allSeasons as Season[]))
+      .subscribe(this._seasons.set);
+  }
+
+  public createSeason(label: string): void {
+    this.createSeasonGql.mutate({variables: {label}})
+      .subscribe(() => this.reloadSeasons());
+  }
+
+  public closeSeason(uuid: string): void {
+    this.closeSeasonGql.mutate({variables: {uuid}})
+      .subscribe(() => this.reloadSeasons());
+  }
+
+  get seasons(): Signal<Season[]> {
+    return this._seasons;
+  }
+}

--- a/frontend/src/app/services/seasons-service.ts
+++ b/frontend/src/app/services/seasons-service.ts
@@ -1,4 +1,4 @@
-import {inject, Injectable, Signal, signal} from "@angular/core";
+import {computed, inject, Injectable, Signal, signal} from "@angular/core";
 import {AllSeasonsGQL, CloseSeasonGQL, CreateSeasonGQL, Season} from "../../generated/graphql";
 import {map} from "rxjs/operators";
 
@@ -12,6 +12,7 @@ export class SeasonsService {
   private closeSeasonGql = inject(CloseSeasonGQL);
 
   private _seasons = signal<Season[]>([]);
+  private _activeSeason = computed(() => this._seasons().find(s => !s.endTime));
 
   constructor() {
     this.reloadSeasons();
@@ -35,5 +36,9 @@ export class SeasonsService {
 
   get seasons(): Signal<Season[]> {
     return this._seasons;
+  }
+
+  get activeSeason(): Signal<Season | undefined> {
+    return this._activeSeason;
   }
 }

--- a/frontend/src/graphql/mutation-close-season.graphql
+++ b/frontend/src/graphql/mutation-close-season.graphql
@@ -1,0 +1,3 @@
+mutation CloseSeason($uuid: String!) {
+  closeSeason(uuid: $uuid)
+}

--- a/frontend/src/graphql/mutation-create-season.graphql
+++ b/frontend/src/graphql/mutation-create-season.graphql
@@ -1,0 +1,8 @@
+mutation CreateSeason($label: String!) {
+  createSeason(label: $label) {
+    uuid
+    label
+    startTime
+    endTime
+  }
+}

--- a/frontend/src/graphql/query-all-seasons.graphql
+++ b/frontend/src/graphql/query-all-seasons.graphql
@@ -1,0 +1,8 @@
+query allSeasons {
+  allSeasons {
+    uuid
+    label
+    startTime
+    endTime
+  }
+}

--- a/frontend/src/graphql/query-last-matches.graphql
+++ b/frontend/src/graphql/query-last-matches.graphql
@@ -1,5 +1,5 @@
-query lastMatches{
-  lastMatches{
+query lastMatches($seasonUuid: String) {
+  lastMatches(seasonUuid: $seasonUuid) {
     uuid
     matchTime
     blueScore

--- a/frontend/src/graphql/query-season-ranking.graphql
+++ b/frontend/src/graphql/query-season-ranking.graphql
@@ -1,0 +1,9 @@
+query seasonRanking($seasonUuid: String!) {
+  seasonRanking(seasonUuid: $seasonUuid) {
+    uuid
+    nickName
+    lastMatchTime
+    defensePoints
+    offensePoints
+  }
+}


### PR DESCRIPTION
Closes #8.

## Design decisions (per our earlier discussion)
- At most one season is active at a time (\`endTime IS NULL\` = active). \`createSeason\` auto-closes whatever was previously active before starting the new one; \`closeSeason\` ends the active one without starting a replacement.
- Matches are auto-tagged with whatever season is active when the score is saved — nullable, so existing match history stays untouched (no active season → \`seasonUuid = null\`).
- Scope: backend CRUD + admin page, plus a season filter wired into match history. Scoreboard *points* are still cumulative all-time (not season-scoped) — that's #7's job, not this one.

## What
- Backend: \`SeasonEO\`/\`SeasonRepository\`/\`SeasonService\`, \`allSeasons\`/\`createSeason\`/\`closeSeason\` GraphQL API. \`MatchEO\` gets a nullable \`seasonUuid\`, auto-set in \`MatchService.saveMatchResults\`. \`lastMatches\` takes an optional \`seasonUuid\` filter.
- Frontend: \`SeasonsService\`, a "Manage seasons" admin page (mirrors manage-players) + nav link, and a season \`<select>\` filter on the match-history table (defaults to "All seasons").
- 11 new/updated backend tests. Also fixed a latent test-isolation gap in \`MatchResourceTest\` (playing a match permanently mutates player points with no reset — only mattered once more than one test in the class started playing matches).

## Test plan
- [x] \`./mvnw test\` — 18/18 backend tests pass
- [x] \`npm run build/lint/test\` — all pass
- [x] Manual browser + direct-API check: started a season, played a match (auto-tagged), filtered match history by that season, started a second season and confirmed the first auto-closed with the right \`endTime\`