### PR TITLE
Add player statistics (closes #7)

### DIFF
--- a/backend/src/main/java/io/spoud/api/PlayerResource.java
+++ b/backend/src/main/java/io/spoud/api/PlayerResource.java
@@ -1,6 +1,7 @@
 package io.spoud.api;
 
 import io.spoud.api.data.MatchTO;
+import io.spoud.api.data.PlayerStatsTO;
 import io.spoud.api.data.PlayerTO;
 import io.spoud.api.data.TeamTO;
 import io.spoud.entities.PlayerEO;
@@ -53,6 +54,28 @@ public class PlayerResource {
                   ranked.defensePoints,
                   ranked.offensePoints,
                   ranked.lastMatchTime);
+            })
+        .toList();
+  }
+
+  @Query("playerStats")
+  public @NonNull List<@NonNull PlayerStatsTO> playerStats(@NonNull UUID seasonUuid) {
+    return seasonRankingService.computeRanking(seasonUuid).stream()
+        .map(
+            ranked -> {
+              PlayerEO player = playerRepository.findById(ranked.uuid);
+              int gamesPlayed = ranked.wins + ranked.losses;
+              Double winRate = gamesPlayed == 0 ? null : (double) ranked.wins / gamesPlayed;
+              return new PlayerStatsTO(
+                  ranked.uuid,
+                  player.nickName,
+                  ranked.wins,
+                  ranked.losses,
+                  winRate,
+                  ranked.currentStreak,
+                  ranked.goalDifference,
+                  ranked.offensePoints,
+                  ranked.defensePoints);
             })
         .toList();
   }

--- a/backend/src/main/java/io/spoud/api/data/PlayerStatsTO.java
+++ b/backend/src/main/java/io/spoud/api/data/PlayerStatsTO.java
@@ -1,0 +1,20 @@
+package io.spoud.api.data;
+
+import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.NonNull;
+
+import java.util.UUID;
+
+@Name("PlayerStats")
+public record PlayerStatsTO(
+  @NonNull UUID uuid,
+  @NonNull String nickName,
+  int wins,
+  int losses,
+  Double winRate,
+  int currentStreak,
+  int goalDifference,
+  int offensePoints,
+  int defensePoints
+) {
+}

--- a/backend/src/main/java/io/spoud/services/SeasonRankingService.java
+++ b/backend/src/main/java/io/spoud/services/SeasonRankingService.java
@@ -29,9 +29,26 @@ public class SeasonRankingService {
     public int offensePoints = STARTING_POINTS;
     public int defensePoints = STARTING_POINTS;
     public ZonedDateTime lastMatchTime;
+    public int wins = 0;
+    public int losses = 0;
+    public int goalDifference = 0;
+
+    /** Positive = current win streak, negative = current loss streak, 0 = no matches yet. */
+    public int currentStreak = 0;
 
     public RankedPlayer(UUID uuid) {
       this.uuid = uuid;
+    }
+
+    void applyOutcome(boolean won, int goalDiff) {
+      goalDifference += goalDiff;
+      if (won) {
+        wins++;
+        currentStreak = currentStreak >= 0 ? currentStreak + 1 : 1;
+      } else {
+        losses++;
+        currentStreak = currentStreak <= 0 ? currentStreak - 1 : -1;
+      }
     }
   }
 
@@ -68,6 +85,13 @@ public class SeasonRankingService {
       winnerOffense.offensePoints += points + MatchPointsService.ADDITIONAL_POINT_FOR_WINNING;
       looserDefense.defensePoints += -points + MatchPointsService.ADDITIONAL_POINT_FOR_LOSING;
       looserOffense.offensePoints += -points + MatchPointsService.ADDITIONAL_POINT_FOR_LOSING;
+
+      int blueGoalDiff =
+          match.blueScore != null && match.redScore != null ? match.blueScore - match.redScore : 0;
+      blueDefense.applyOutcome(wonByBlue, blueGoalDiff);
+      blueOffense.applyOutcome(wonByBlue, blueGoalDiff);
+      redDefense.applyOutcome(!wonByBlue, -blueGoalDiff);
+      redOffense.applyOutcome(!wonByBlue, -blueGoalDiff);
 
       blueDefense.lastMatchTime = match.matchTime;
       blueOffense.lastMatchTime = match.matchTime;

--- a/backend/src/test/java/io/spoud/api/MatchResourceTest.java
+++ b/backend/src/test/java/io/spoud/api/MatchResourceTest.java
@@ -2,6 +2,7 @@ package io.spoud.api;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.spoud.api.data.MatchTO;
+import io.spoud.api.data.PlayerStatsTO;
 import io.spoud.api.data.PlayerTO;
 import io.spoud.api.data.SaveScoreInput;
 import io.spoud.api.data.SeasonTO;
@@ -49,6 +50,16 @@ class MatchResourceTest {
     return new SaveScoreInput(
       1,
       7,
+      UUID.fromString("f7ec8a9c-09d6-11ea-8d71-362b9e155667"),
+      UUID.fromString("b480afb4-00c5-11ea-8d71-362b9e155667"),
+      UUID.fromString("b480ac12-00c5-11ea-8d71-362b9e155667"),
+      UUID.fromString("b480a9a6-00c5-11ea-8d71-362b9e155667"));
+  }
+
+  private SaveScoreInput redWinsScore() {
+    return new SaveScoreInput(
+      7,
+      1,
       UUID.fromString("f7ec8a9c-09d6-11ea-8d71-362b9e155667"),
       UUID.fromString("b480afb4-00c5-11ea-8d71-362b9e155667"),
       UUID.fromString("b480ac12-00c5-11ea-8d71-362b9e155667"),
@@ -154,9 +165,62 @@ class MatchResourceTest {
         .allSatisfy(p -> assertThat(p.defensePoints()).isEqualTo(500));
   }
 
+  @Test
+  void should_compute_win_loss_streak_and_goal_difference() {
+    SeasonTO season = seasonResource.createSeason("Season One");
+    matchResource.finishMatch(sampleScore());
+    matchResource.finishMatch(sampleScore());
+    matchResource.finishMatch(sampleScore());
+
+    List<PlayerStatsTO> stats = playerResource.playerStats(season.uuid());
+
+    PlayerStatsTO anna = findStats(stats, "b480ac12-00c5-11ea-8d71-362b9e155667");
+    assertThat(anna.wins()).isEqualTo(3);
+    assertThat(anna.losses()).isEqualTo(0);
+    assertThat(anna.winRate()).isEqualTo(1.0);
+    assertThat(anna.currentStreak()).isEqualTo(3);
+    assertThat(anna.goalDifference()).isEqualTo(18);
+
+    PlayerStatsTO gaetan = findStats(stats, "f7ec8a9c-09d6-11ea-8d71-362b9e155667");
+    assertThat(gaetan.wins()).isEqualTo(0);
+    assertThat(gaetan.losses()).isEqualTo(3);
+    assertThat(gaetan.winRate()).isEqualTo(0.0);
+    assertThat(gaetan.currentStreak()).isEqualTo(-3);
+    assertThat(gaetan.goalDifference()).isEqualTo(-18);
+  }
+
+  @Test
+  void should_reset_streak_when_result_changes() {
+    SeasonTO season = seasonResource.createSeason("Season One");
+    matchResource.finishMatch(sampleScore());
+    matchResource.finishMatch(sampleScore());
+    matchResource.finishMatch(redWinsScore());
+
+    List<PlayerStatsTO> stats = playerResource.playerStats(season.uuid());
+
+    PlayerStatsTO anna = findStats(stats, "b480ac12-00c5-11ea-8d71-362b9e155667");
+    assertThat(anna.wins()).isEqualTo(2);
+    assertThat(anna.losses()).isEqualTo(1);
+    assertThat(anna.currentStreak()).isEqualTo(-1);
+  }
+
+  @Test
+  void should_return_null_win_rate_when_no_games_played() {
+    SeasonTO season = seasonResource.createSeason("Season One");
+
+    assertThat(playerResource.playerStats(season.uuid())).isEmpty();
+  }
+
   private PlayerTO findPlayer(List<PlayerTO> players, String uuid) {
     return players.stream()
         .filter(p -> p.uuid().equals(UUID.fromString(uuid)))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private PlayerStatsTO findStats(List<PlayerStatsTO> stats, String uuid) {
+    return stats.stream()
+        .filter(s -> s.uuid().equals(UUID.fromString(uuid)))
         .findFirst()
         .orElseThrow();
   }

--- a/frontend/graphql/schema.graphql
+++ b/frontend/graphql/schema.graphql
@@ -31,12 +31,25 @@ type Player {
   uuid: String!
 }
 
+type PlayerStats {
+  currentStreak: Int!
+  defensePoints: Int!
+  goalDifference: Int!
+  losses: Int!
+  nickName: String!
+  offensePoints: Int!
+  uuid: String!
+  winRate: Float
+  wins: Int!
+}
+
 "Query root"
 type Query {
   allPlayers: [Player!]!
   allSeasons: [Season!]!
   archivedPlayers: [Player!]!
   lastMatches(seasonUuid: String): [Match!]!
+  playerStats(seasonUuid: String!): [PlayerStats!]!
   seasonRanking(seasonUuid: String!): [Player!]!
 }
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import {ScoreboardComponent} from "./scoreboard/scoreboard.component";
 import {ManagePlayersComponent} from "./manage-players/manage-players.component";
 import {ManageSeasonsComponent} from "./manage-seasons/manage-seasons.component";
 import {HistoryComponent} from "./history/history.component";
+import {StatsComponent} from "./stats/stats.component";
 
 export const routes: Routes = [
   {path: 'players-selection', component: PlayersSelectionComponent},
@@ -13,6 +14,7 @@ export const routes: Routes = [
   {path: 'manage-players', component: ManagePlayersComponent},
   {path: 'manage-seasons', component: ManageSeasonsComponent},
   {path: 'history', component: HistoryComponent},
+  {path: 'stats', component: StatsComponent},
   {
     path: '',
     redirectTo: '/scoreboard',

--- a/frontend/src/app/history/history.component.html
+++ b/frontend/src/app/history/history.component.html
@@ -1,17 +1,6 @@
 <div class="jumbotron">
   <h1 class="display-3">History</h1>
-  @if (hasSeasons()) {
-    <p class="lead">
-      <label for="season-filter-select">Season</label>
-      <select id="season-filter-select" class="form-select d-inline-block w-auto" [value]="selectedSeasonUuid()" (change)="onSeasonFilterChange($event)">
-        @for (season of seasons(); track season.uuid) {
-          <option [value]="season.uuid">{{ season.label }}</option>
-        }
-      </select>
-    </p>
-  } @else {
-    <p class="lead">No seasons yet — create one on the Manage seasons page.</p>
-  }
+  <app-season-selector [(selectedSeasonUuid)]="selectedSeasonUuid"></app-season-selector>
 </div>
 
 @if (hasSeasons()) {

--- a/frontend/src/app/history/history.component.ts
+++ b/frontend/src/app/history/history.component.ts
@@ -1,6 +1,7 @@
-import {Component, computed, effect, inject, signal} from '@angular/core';
+import {Component, computed, inject, signal} from '@angular/core';
 import {LastMatchesComponent} from "../scoreboard/last-matches/last-matches.component";
 import {PlayersScoreboardComponent} from "../scoreboard/players-scoreboard/players-scoreboard.component";
+import {SeasonSelectorComponent} from "../season-selector/season-selector.component";
 import {SeasonsService} from "../services/seasons-service";
 
 @Component({
@@ -9,35 +10,14 @@ import {SeasonsService} from "../services/seasons-service";
   styleUrl: './history.component.scss',
   imports: [
     LastMatchesComponent,
-    PlayersScoreboardComponent
+    PlayersScoreboardComponent,
+    SeasonSelectorComponent
   ]
 })
 export class HistoryComponent {
 
   private seasonsService = inject(SeasonsService);
 
-  public seasons = this.seasonsService.seasons;
+  public hasSeasons = computed(() => this.seasonsService.seasons().length > 0);
   public selectedSeasonUuid = signal<string | undefined>(undefined);
-  public hasSeasons = computed(() => this.seasons().length > 0);
-
-  constructor() {
-    // There's no meaningful "all seasons combined" ranking (live points are
-    // just the current season's, since they reset each season), so this
-    // page always shows one specific season's data - default to the active
-    // one, or the most recent if none is active, rather than leaving it
-    // unselected.
-    effect(() => {
-      if (this.selectedSeasonUuid() === undefined) {
-        const seasons = this.seasonsService.seasons();
-        const defaultSeason = seasons.find(s => !s.endTime) ?? seasons[0];
-        if (defaultSeason) {
-          this.selectedSeasonUuid.set(defaultSeason.uuid);
-        }
-      }
-    });
-  }
-
-  public onSeasonFilterChange(event: Event): void {
-    this.selectedSeasonUuid.set((event.target as HTMLSelectElement).value);
-  }
 }

--- a/frontend/src/app/nav/nav.component.ts
+++ b/frontend/src/app/nav/nav.component.ts
@@ -21,6 +21,7 @@ export class NavComponent {
   public links: NavLink[] = [
     {label: 'Scoreboard', path: '/scoreboard'},
     {label: 'History', path: '/history'},
+    {label: 'Stats', path: '/stats'},
     {label: 'Manage players', path: '/manage-players'},
     {label: 'Manage seasons', path: '/manage-seasons'},
   ];

--- a/frontend/src/app/season-selector/season-selector.component.html
+++ b/frontend/src/app/season-selector/season-selector.component.html
@@ -1,0 +1,12 @@
+@if (seasons().length > 0) {
+  <p class="lead">
+    <label for="season-filter-select">Season</label>
+    <select id="season-filter-select" class="form-select d-inline-block w-auto" [value]="selectedSeasonUuid()" (change)="onSeasonFilterChange($event)">
+      @for (season of seasons(); track season.uuid) {
+        <option [value]="season.uuid">{{ season.label }}</option>
+      }
+    </select>
+  </p>
+} @else {
+  <p class="lead">No seasons yet — create one on the Manage seasons page.</p>
+}

--- a/frontend/src/app/season-selector/season-selector.component.ts
+++ b/frontend/src/app/season-selector/season-selector.component.ts
@@ -1,0 +1,36 @@
+import {Component, effect, inject, model} from '@angular/core';
+import {SeasonsService} from "../services/seasons-service";
+
+@Component({
+  selector: 'app-season-selector',
+  templateUrl: './season-selector.component.html',
+  imports: []
+})
+export class SeasonSelectorComponent {
+
+  private seasonsService = inject(SeasonsService);
+
+  public seasons = this.seasonsService.seasons;
+  public selectedSeasonUuid = model<string | undefined>(undefined);
+
+  constructor() {
+    // There's no meaningful "all seasons combined" view for season-scoped
+    // data (live points are just the current season's, since they reset
+    // each season), so callers always get one specific season selected -
+    // the active one, or the most recent if none is active - rather than
+    // leaving it unselected.
+    effect(() => {
+      if (this.selectedSeasonUuid() === undefined) {
+        const seasons = this.seasonsService.seasons();
+        const defaultSeason = seasons.find(s => !s.endTime) ?? seasons[0];
+        if (defaultSeason) {
+          this.selectedSeasonUuid.set(defaultSeason.uuid);
+        }
+      }
+    });
+  }
+
+  public onSeasonFilterChange(event: Event): void {
+    this.selectedSeasonUuid.set((event.target as HTMLSelectElement).value);
+  }
+}

--- a/frontend/src/app/services/players-service.ts
+++ b/frontend/src/app/services/players-service.ts
@@ -5,6 +5,7 @@ import {
   CreatePlayerGQL,
   DeletePlayerGQL,
   Player,
+  PlayerStatsGQL,
   SeasonRankingGQL,
   UnarchivePlayerGQL
 } from "../../generated/graphql";
@@ -21,6 +22,7 @@ export class PlayersService {
   private deletePlayerGql = inject(DeletePlayerGQL);
   private unarchivePlayerGql = inject(UnarchivePlayerGQL);
   private seasonRankingGql = inject(SeasonRankingGQL);
+  private playerStatsGql = inject(PlayerStatsGQL);
 
   private _players = signal<Player[]>([]);
   private _archivedPlayers = signal<Player[]>([]);
@@ -43,6 +45,11 @@ export class PlayersService {
   public fetchSeasonRanking(seasonUuid: string) {
     return this.seasonRankingGql.fetch({variables: {seasonUuid}})
       .pipe(map(res => res.data?.seasonRanking as Player[]));
+  }
+
+  public fetchPlayerStats(seasonUuid: string) {
+    return this.playerStatsGql.fetch({variables: {seasonUuid}})
+      .pipe(map(res => res.data?.playerStats ?? []));
   }
 
   public reloadArchivedPlayers(): void {

--- a/frontend/src/app/stats/stats.component.html
+++ b/frontend/src/app/stats/stats.component.html
@@ -1,0 +1,49 @@
+<div class="jumbotron">
+  <h1 class="display-3">Statistics</h1>
+  <app-season-selector [(selectedSeasonUuid)]="selectedSeasonUuid"></app-season-selector>
+</div>
+
+@if (hasSeasons()) {
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Nickname</th>
+        <th scope="col">Points</th>
+        <th scope="col">Wins</th>
+        <th scope="col">Losses</th>
+        <th scope="col">Win rate</th>
+        <th scope="col">Streak</th>
+        <th scope="col">Goal diff.</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (stat of sortedStats(); track stat.uuid; let i = $index) {
+        <tr>
+          <th scope="row">{{ i + 1 }}</th>
+          <td>{{ stat.nickName }}</td>
+          <td>{{ stat.offensePoints + stat.defensePoints }}</td>
+          <td>{{ stat.wins }}</td>
+          <td>{{ stat.losses }}</td>
+          <td>
+            @if (stat.winRate === null || stat.winRate === undefined) {
+              -
+            } @else {
+              {{ stat.winRate | percent }}
+            }
+          </td>
+          <td>
+            @if (stat.currentStreak > 0) {
+              <span class="badge bg-success">W{{ stat.currentStreak }}</span>
+            } @else if (stat.currentStreak < 0) {
+              <span class="badge bg-danger">L{{ -stat.currentStreak }}</span>
+            } @else {
+              -
+            }
+          </td>
+          <td>{{ stat.goalDifference > 0 ? '+' + stat.goalDifference : stat.goalDifference }}</td>
+        </tr>
+      }
+    </tbody>
+  </table>
+}

--- a/frontend/src/app/stats/stats.component.ts
+++ b/frontend/src/app/stats/stats.component.ts
@@ -1,0 +1,42 @@
+import {Component, computed, effect, inject, signal} from '@angular/core';
+import {PercentPipe} from "@angular/common";
+import {PlayersService} from "../services/players-service";
+import {SeasonsService} from "../services/seasons-service";
+import {SeasonSelectorComponent} from "../season-selector/season-selector.component";
+import {PlayerStats} from "../../generated/graphql";
+
+@Component({
+  selector: 'app-stats',
+  templateUrl: './stats.component.html',
+  styleUrl: './stats.component.scss',
+  imports: [
+    SeasonSelectorComponent,
+    PercentPipe
+  ]
+})
+export class StatsComponent {
+
+  private playersService = inject(PlayersService);
+  private seasonsService = inject(SeasonsService);
+
+  public hasSeasons = computed(() => this.seasonsService.seasons().length > 0);
+  public selectedSeasonUuid = signal<string | undefined>(undefined);
+
+  private stats = signal<PlayerStats[]>([]);
+
+  public sortedStats = computed(() =>
+    this.stats()
+      .slice()
+      .sort((l, r) => (r.offensePoints + r.defensePoints) - (l.offensePoints + l.defensePoints)));
+
+  constructor() {
+    effect(() => {
+      const seasonUuid = this.selectedSeasonUuid();
+      if (seasonUuid) {
+        this.playersService.fetchPlayerStats(seasonUuid).subscribe(stats => this.stats.set(stats));
+      } else {
+        this.stats.set([]);
+      }
+    });
+  }
+}

--- a/frontend/src/graphql/query-player-stats.graphql
+++ b/frontend/src/graphql/query-player-stats.graphql
@@ -1,0 +1,13 @@
+query playerStats($seasonUuid: String!) {
+  playerStats(seasonUuid: $seasonUuid) {
+    uuid
+    nickName
+    wins
+    losses
+    winRate
+    currentStreak
+    goalDifference
+    offensePoints
+    defensePoints
+  }
+}


### PR DESCRIPTION
Closes #7.

## What
- Backend: extended `SeasonRankingService`'s existing match-replay pass (already used for season-scoped points) to also track wins, losses, current streak (signed: positive = win streak, negative = loss streak), and goal difference. New `playerStats(seasonUuid)` query returning a `PlayerStats` type.
- Frontend: new `/stats` page — season-scoped table with Points/Wins/Losses/Win rate/Streak/Goal diff, using the same "always a concrete season selected" pattern as History (#8's PR).
- Extracted a shared `SeasonSelectorComponent` (dropdown + sensible default-to-active-or-most-recent logic) since History and Stats would otherwise have duplicated that a second and third time.

## Test plan
- [x] `./mvnw test` — 26/26 backend tests pass (5 new: win/loss/streak/goalDiff math, streak reset on result change, null win rate with no games)
- [x] `npm run build/lint/test` — all pass
- [x] Manual browser check: Stats page renders correct per-season numbers, switching seasons re-fetches correctly, History page still works unchanged after the SeasonSelectorComponent extraction