### PR TITLE
Fix frontend publish job silently skipped on push to main

### DIFF
--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -59,7 +59,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    # needs.build.result must be checked explicitly: build's own condition
+    # uses always() to run despite the (intentionally, on push) skipped
+    # changes job, but that means the default implicit success() check here
+    # would still see a skipped job upstream and skip publish too.
+    if: always() && needs.build.result == 'success' && github.ref == 'refs/heads/main'
 
     steps:
 


### PR DESCRIPTION
## Summary
- `publish`'s `if: github.ref == 'refs/heads/main'` had no `always()`/`success()` in it, so GitHub Actions implicitly wraps it as `success() && ...` — and `success()` walks the *entire transitive* `needs` graph, not just direct dependencies.
- Since #393, the `changes` job is (correctly) skipped on `push` events, and `build`'s own condition explicitly uses `always()` to still run despite that skip. But `publish` still sees the skipped `changes` job upstream via `needs: build`, so its implicit `success()` check evaluates to skip too.
- Net effect: **every push to `main` since #393 merged has skipped `publish`** for the frontend, even though `build` succeeds. `spoud/toeggelomat-frontend:latest` on Docker Hub has been stale since before that PR — this is what's currently deployed and doesn't reflect the latest code.
- Fix: make `publish`'s condition explicit — `always() && needs.build.result == 'success' && github.ref == 'refs/heads/main'` — same pattern already used on `build`.

## Test plan
- [ ] Merge to `main` and confirm the `publish` job actually runs and pushes `spoud/toeggelomat-frontend:latest`
- [ ] Confirm the backend workflow (which doesn't have a `changes` job) is unaffected — its `publish` already runs fine